### PR TITLE
Give every typed field real terminal line-editing

### DIFF
--- a/crates/nebula-tui/src/app.rs
+++ b/crates/nebula-tui/src/app.rs
@@ -1,6 +1,7 @@
 //! TUI state: the Elm-ish Model.
 
 use crate::git_diff::DiffFile;
+use crate::text_input::TextInput;
 use nebula_core::{
     Agent, AgentId, AgentKind, AgentStatus, Note, NoteId, NoteOwner, Project, ProjectId,
     SessionRef, TerminalId, TerminalTab, Workspace, WorkspaceId, Worktree, WorktreeId,
@@ -253,7 +254,7 @@ pub enum PromptKind {
 pub struct PromptDialog {
     pub title: String,
     pub label: String,
-    pub input: String,
+    pub input: TextInput,
     pub kind: PromptKind,
     /// Live directory listing under the input (path prompts only): the
     /// typed parent's subdirectories narrowed by the partial segment.
@@ -275,7 +276,7 @@ impl PromptDialog {
         let mut prompt = Self {
             title: title.into(),
             label: label.into(),
-            input: input.into(),
+            input: TextInput::with_text(input),
             kind,
             dirs: Vec::new(),
             hover: None,
@@ -327,7 +328,7 @@ impl PromptDialog {
             return;
         };
         let (parent, _) = crate::completion::split_input(&self.input);
-        self.input = format!("{parent}{}/", entry.name);
+        self.input.set_text(format!("{parent}{}/", entry.name));
         self.refresh_dirs();
     }
 
@@ -337,11 +338,12 @@ impl PromptDialog {
     pub fn ascend(&mut self) {
         let (parent, partial) = crate::completion::split_input(&self.input);
         if !partial.is_empty() {
-            self.input = parent.to_string();
+            let parent = parent.to_string();
+            self.input.set_text(parent);
             self.refresh_dirs();
             return;
         }
-        let mut path = self.input.clone();
+        let mut path = self.input.to_string();
         if path == "~/" {
             match Self::home() {
                 Some(home) => path = format!("{}/", home.display()),
@@ -354,7 +356,7 @@ impl PromptDialog {
         path.pop(); // the trailing '/'
         let cut = path.rfind('/').map(|i| i + 1).unwrap_or(0);
         path.truncate(cut);
-        self.input = path;
+        self.input.set_text(path);
         self.refresh_dirs();
     }
 
@@ -382,7 +384,7 @@ pub struct DiffView {
     pub branch: String,
     pub files: Vec<DiffFile>,
     /// Type-to-filter query over `files` paths; always live.
-    pub filter: String,
+    pub filter: TextInput,
     /// Visible rows: `files` narrowed by `filter`, best matches first
     /// (git order when the filter is empty); reviewed ✓ files always sink
     /// to the bottom.
@@ -426,7 +428,7 @@ impl DiffView {
             root,
             branch,
             files,
-            filter: String::new(),
+            filter: TextInput::new(),
             matches: Vec::new(),
             selected: 0,
             diff: String::new(),
@@ -590,7 +592,7 @@ pub struct PaletteMatch {
 pub struct Palette {
     pub items: Vec<PaletteItem>,
     /// Type-to-filter query over `items` texts; always live.
-    pub query: String,
+    pub query: TextInput,
     /// Visible rows: `items` narrowed by `query`, best matches first (build
     /// order when the query is empty).
     pub matches: Vec<PaletteMatch>,
@@ -611,7 +613,7 @@ impl Palette {
     pub fn new(tree: &Tree, show_archived: bool, enter_attaches: bool) -> Self {
         let mut palette = Self {
             items: build_palette_items(tree, show_archived),
-            query: String::new(),
+            query: TextInput::new(),
             matches: Vec::new(),
             selected: 0,
             enter_attaches,
@@ -740,7 +742,7 @@ pub struct FileFinder {
     /// Paths relative to `root`, in git listing order.
     pub files: Vec<String>,
     /// Type-to-filter query over `files`; always live.
-    pub query: String,
+    pub query: TextInput,
     /// Visible rows: `files` narrowed by `query`, best matches first
     /// (listing order when the query is empty).
     pub matches: Vec<FinderMatch>,
@@ -760,7 +762,7 @@ impl FileFinder {
             branch,
             editor,
             files,
-            query: String::new(),
+            query: TextInput::new(),
             matches: Vec::new(),
             selected: 0,
             area: Rect::default(),
@@ -811,7 +813,7 @@ pub struct GrepView {
     /// setting, default vim), captured at open time.
     pub editor: String,
     /// The search text; every edit re-runs the grep.
-    pub query: String,
+    pub query: TextInput,
     /// Current results, best-first in git grep order (path, then line).
     pub hits: Vec<crate::grep_search::GrepHit>,
     /// The search stopped at the result cap — the title says so.
@@ -833,7 +835,7 @@ impl GrepView {
             root,
             branch,
             editor,
-            query: String::new(),
+            query: TextInput::new(),
             hits: Vec::new(),
             truncated: false,
             error: None,
@@ -889,7 +891,7 @@ impl GrepView {
 pub struct NoteInput {
     /// None = creating a new note; Some = rewriting that note's text.
     pub editing: Option<NoteId>,
-    pub text: String,
+    pub text: TextInput,
 }
 
 /// Note notes modal (`o`) for one owner — a project (high-level notes) or
@@ -942,7 +944,7 @@ pub struct HostsView {
     pub selected: usize,
     /// Active "connect to a new destination" input (`a`), if any — typed as
     /// `user@host [dir]`, Enter connects like a `nebula ssh` invocation.
-    pub input: Option<String>,
+    pub input: Option<TextInput>,
     /// Whole modal rect, written back during draw so clicks outside close.
     pub area: Rect,
     /// Screen rect of the host rows, written back during draw so clicks can

--- a/crates/nebula-tui/src/event_loop.rs
+++ b/crates/nebula-tui/src/event_loop.rs
@@ -7,6 +7,7 @@ use crate::app::{
     PromptKind, SessionRow, SettingsView, SplitterDrag, SubmenuKind, TermSelection,
     WorktreeRollback,
 };
+use crate::text_input::TextInput;
 use crate::tree_browser::TreeBrowser;
 use crate::vim_term::{VimEvent, VimTerm};
 use crate::{ipc, keys, ui};
@@ -495,6 +496,9 @@ fn handle_terminal_event(app: &mut App, event: Event, out: &mut Vec<ClientReques
                 vim.input(&data);
             }
         }
+        // An overlay with a live text field takes the paste: ⌘V into a note,
+        // a filter, or the ssh destination lands where the caret is.
+        Event::Paste(text) if paste_into_overlay(app, &text) => {}
         Event::Paste(text) => {
             if app.focus == Focus::Terminal && app.term_locked {
                 if let Some(term) = &app.term {
@@ -512,6 +516,55 @@ fn handle_terminal_event(app: &mut App, event: Event, out: &mut Vec<ClientReques
         Event::Resize(_, _) => app.dirty = true,
         _ => {}
     }
+}
+
+/// Route a bracketed paste into whatever text field the open overlay has
+/// live. Returns false when nothing is typing, so the paste falls through to
+/// the terminal pane.
+fn paste_into_overlay(app: &mut App, text: &str) -> bool {
+    let Some(overlay) = &mut app.overlay else {
+        return false;
+    };
+    match overlay {
+        Overlay::Prompt(prompt) => {
+            prompt.input.insert_str(text);
+            prompt.refresh_dirs();
+        }
+        Overlay::Palette(palette) => {
+            palette.query.insert_str(text);
+            palette.apply_filter();
+        }
+        Overlay::Files(finder) => {
+            finder.query.insert_str(text);
+            finder.apply_filter();
+        }
+        Overlay::Grep(view) => {
+            view.query.insert_str(text);
+            view.run_search();
+        }
+        Overlay::Tree(view) => {
+            view.filter.insert_str(text);
+            view.apply_filter();
+        }
+        Overlay::Diff(view) => {
+            view.filter.insert_str(text);
+            if view.apply_filter() {
+                crate::git_diff::load_selected_diff(view);
+            }
+        }
+        // These two only type while their add/edit input is open.
+        Overlay::Notes(view) => match &mut view.input {
+            Some(input) => input.text.insert_str(text),
+            None => return false,
+        },
+        Overlay::Hosts(view) => match &mut view.input {
+            Some(input) => input.insert_str(text),
+            None => return false,
+        },
+        _ => return false,
+    }
+    app.dirty = true;
+    true
 }
 
 fn handle_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>) {
@@ -2029,7 +2082,6 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
             _ => {}
         },
         Overlay::Hosts(view) => {
-            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
             // Typing a new destination (`a`): the input owns printable keys.
             if let Some(input) = &mut view.input {
                 match key.code {
@@ -2045,12 +2097,11 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                             app.should_quit = true;
                         }
                     }
-                    KeyCode::Backspace => {
-                        input.pop();
+                    // Everything else is the line editor's: arrows,
+                    // ⌥←/⌥→ by word, the readline chords (text_input).
+                    _ => {
+                        input.handle_key(&key);
                     }
-                    KeyCode::Char('u') if ctrl => input.clear(),
-                    KeyCode::Char(c) if !ctrl => input.push(c),
-                    _ => {}
                 }
                 return;
             }
@@ -2062,7 +2113,7 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 KeyCode::Char('k') | KeyCode::Up => view.selected = view.selected.saturating_sub(1),
                 // A destination the list doesn't have yet — typed here so an
                 // open nebula never needs a shell for `nebula ssh`.
-                KeyCode::Char('a') | KeyCode::Char('n') => view.input = Some(String::new()),
+                KeyCode::Char('a') | KeyCode::Char('n') => view.input = Some(TextInput::new()),
                 // Enter hands off: quit the TUI, then the binary execs a
                 // fresh `nebula ssh` at the entry (the daemon and its
                 // sessions stay up).
@@ -2156,7 +2207,7 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 // on the input row it submits the typed path as before.
                 let mut prompt = prompt.clone();
                 if let Some(path) = prompt.hovered_path() {
-                    prompt.input = path;
+                    prompt.input.set_text(path);
                 }
                 app.overlay = None;
                 submit_prompt(app, prompt, out);
@@ -2165,36 +2216,40 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 let home = std::env::var_os("HOME").map(std::path::PathBuf::from);
                 let result = crate::completion::complete_path(&prompt.input, home.as_deref());
                 if let Some(completed) = result.completed {
-                    prompt.input = completed;
+                    prompt.input.set_text(completed);
                     prompt.refresh_dirs();
                 }
             }
             KeyCode::Down if prompt.completes_paths() => prompt.move_hover(1),
             KeyCode::Up if prompt.completes_paths() => prompt.move_hover(-1),
+            // ←/→ stay the path browser's dive/ascend here — the one
+            // prompt where they are already spoken for. Caret motion in a
+            // path is ⌥←/⌥→ (by segment), Ctrl+B/F, Home/End.
             KeyCode::Right if prompt.completes_paths() => {
                 if let Some(i) = prompt.hover {
                     prompt.dive(i);
                 }
             }
             KeyCode::Left if prompt.completes_paths() => prompt.ascend(),
-            KeyCode::Backspace => {
-                prompt.input.pop();
+            // The untouched "~/" prefill yields to an absolute (or
+            // re-typed tilde) path — no clearing required first.
+            KeyCode::Char(c)
+                if prompt.completes_paths()
+                    && prompt.input == "~/"
+                    && (c == '/' || c == '~')
+                    && !key
+                        .modifiers
+                        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+            {
+                prompt.input.set_text(c.to_string());
                 prompt.refresh_dirs();
             }
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                prompt.input.clear();
-                prompt.refresh_dirs();
-            }
-            KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // The untouched "~/" prefill yields to an absolute (or
-                // re-typed tilde) path — no clearing required first.
-                if prompt.completes_paths() && prompt.input == "~/" && (c == '/' || c == '~') {
-                    prompt.input.clear();
+            // Everything else is the line editor's (see text_input).
+            _ => {
+                if prompt.input.handle_key(&key).changed() {
+                    prompt.refresh_dirs();
                 }
-                prompt.input.push(c);
-                prompt.refresh_dirs();
             }
-            _ => {}
         },
         Overlay::Confirm(confirm) => match key.code {
             KeyCode::Esc | KeyCode::Char('n') => app.overlay = None,
@@ -2221,15 +2276,9 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 }
                 KeyCode::Esc => app.overlay = None,
                 KeyCode::Char('d') if ctrl => view.scroll_by(half),
-                // Ctrl+u clears an active filter (the app-wide clear-input
-                // key); only with nothing typed does it keep its scroll role.
-                KeyCode::Char('u') if ctrl && !view.filter.is_empty() => {
-                    view.filter.clear();
-                    if view.apply_filter() {
-                        crate::git_diff::load_selected_diff(view);
-                    }
-                }
-                KeyCode::Char('u') if ctrl => view.scroll_by(-half),
+                // Ctrl+u is the line editor's kill-to-start while something
+                // is typed; only with an empty filter does it scroll.
+                KeyCode::Char('u') if ctrl && view.filter.is_empty() => view.scroll_by(-half),
                 // Ctrl+r toggles the reviewed ✓ on the selected file —
                 // nebula-side bookkeeping only, no git state is touched.
                 // Reviewed files sink to the bottom; marking advances to the
@@ -2260,19 +2309,13 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 KeyCode::PageUp => view.scroll_by(-page),
                 KeyCode::Home => view.scroll = 0,
                 KeyCode::End => view.scroll = view.max_scroll(),
-                KeyCode::Backspace => {
-                    if view.filter.pop().is_some() && view.apply_filter() {
+                // Everything else feeds the always-on fuzzy filter, which
+                // edits like a terminal line (see text_input).
+                _ => {
+                    if view.filter.handle_key(&key).changed() && view.apply_filter() {
                         crate::git_diff::load_selected_diff(view);
                     }
                 }
-                // Everything printable feeds the always-on fuzzy filter.
-                KeyCode::Char(c) if !ctrl => {
-                    view.filter.push(c);
-                    if view.apply_filter() {
-                        crate::git_diff::load_selected_diff(view);
-                    }
-                }
-                _ => {}
             }
         }
         Overlay::Palette(palette) => {
@@ -2311,20 +2354,13 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                         jump_to_target(app, target, false, out);
                     }
                 }
-                KeyCode::Backspace => {
-                    if palette.query.pop().is_some() {
+                // Everything else edits the query like a terminal line
+                // (see text_input).
+                _ => {
+                    if palette.query.handle_key(&key).changed() {
                         palette.apply_filter();
                     }
                 }
-                KeyCode::Char('u') if ctrl => {
-                    palette.query.clear();
-                    palette.apply_filter();
-                }
-                KeyCode::Char(c) if !ctrl => {
-                    palette.query.push(c);
-                    palette.apply_filter();
-                }
-                _ => {}
             }
         }
         Overlay::Files(finder) => {
@@ -2358,20 +2394,13 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                         });
                     }
                 }
-                KeyCode::Backspace => {
-                    if finder.query.pop().is_some() {
+                // Everything else edits the query like a terminal line
+                // (see text_input).
+                _ => {
+                    if finder.query.handle_key(&key).changed() {
                         finder.apply_filter();
                     }
                 }
-                KeyCode::Char('u') if ctrl => {
-                    finder.query.clear();
-                    finder.apply_filter();
-                }
-                KeyCode::Char(c) if !ctrl => {
-                    finder.query.push(c);
-                    finder.apply_filter();
-                }
-                _ => {}
             }
         }
         Overlay::Grep(view) => {
@@ -2392,20 +2421,13 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 // Enter opens the hit in the editor modal; the overlay stays
                 // open underneath so quitting the editor returns here.
                 KeyCode::Enter => open_selected_hit_in_editor(app),
-                KeyCode::Backspace => {
-                    if view.query.pop().is_some() {
+                // Everything else edits the query like a terminal line
+                // (see text_input).
+                _ => {
+                    if view.query.handle_key(&key).changed() {
                         view.run_search();
                     }
                 }
-                KeyCode::Char('u') if ctrl => {
-                    view.query.clear();
-                    view.run_search();
-                }
-                KeyCode::Char(c) if !ctrl => {
-                    view.query.push(c);
-                    view.run_search();
-                }
-                _ => {}
             }
         }
         Overlay::Tree(view) => {
@@ -2424,13 +2446,9 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 // The preview scrolls on the diff-modal keys: ⇧↑/↓ lines,
                 // Ctrl+d/u half pages, PageUp/Down, Home/End.
                 KeyCode::Char('d') if ctrl => view.scroll_by(half),
-                // Ctrl+u clears an active filter (the app-wide clear-input
-                // key); only with nothing typed does it keep its scroll role.
-                KeyCode::Char('u') if ctrl && !view.filter.is_empty() => {
-                    view.filter.clear();
-                    view.apply_filter();
-                }
-                KeyCode::Char('u') if ctrl => view.scroll_by(-half),
+                // Ctrl+u is the line editor's kill-to-start while something
+                // is typed; only with an empty filter does it scroll.
+                KeyCode::Char('u') if ctrl && view.filter.is_empty() => view.scroll_by(-half),
                 KeyCode::Down if shift => view.scroll_by(1),
                 KeyCode::Up if shift => view.scroll_by(-1),
                 KeyCode::PageDown => view.scroll_by(page),
@@ -2465,17 +2483,13 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                         });
                     }
                 }
-                KeyCode::Backspace => {
-                    if view.filter.pop().is_some() {
+                // Everything else feeds the always-on fuzzy filter, which
+                // edits like a terminal line (see text_input).
+                _ => {
+                    if view.filter.handle_key(&key).changed() {
                         view.apply_filter();
                     }
                 }
-                // Everything printable feeds the always-on fuzzy filter.
-                KeyCode::Char(c) if !ctrl => {
-                    view.filter.push(c);
-                    view.apply_filter();
-                }
-                _ => {}
             }
         }
         Overlay::Notes(view) => {
@@ -2504,7 +2518,6 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 .collect();
             let selected = view.selected.min(rows.len().saturating_sub(1));
             view.selected = selected;
-            let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
             let cmd = if let Some(input) = &mut view.input {
                 match key.code {
                     KeyCode::Esc => NoteCmd::CancelInput,
@@ -2514,19 +2527,12 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                         (Some(id), text) => NoteCmd::Update(id.clone(), text.to_string()),
                         (None, text) => NoteCmd::Create(text.to_string()),
                     },
-                    KeyCode::Backspace => {
-                        input.text.pop();
+                    // Everything else is the line editor's: arrows, ⌥←/⌥→
+                    // by word, the readline chords (see text_input).
+                    _ => {
+                        input.text.handle_key(&key);
                         NoteCmd::Nothing
                     }
-                    KeyCode::Char('u') if ctrl => {
-                        input.text.clear();
-                        NoteCmd::Nothing
-                    }
-                    KeyCode::Char(c) if !ctrl => {
-                        input.text.push(c);
-                        NoteCmd::Nothing
-                    }
-                    _ => NoteCmd::Nothing,
                 }
             } else {
                 match key.code {
@@ -2568,13 +2574,15 @@ fn handle_overlay_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>
                 NoteCmd::StartCreate => {
                     view.input = Some(NoteInput {
                         editing: None,
-                        text: String::new(),
+                        text: TextInput::new(),
                     });
                 }
                 NoteCmd::StartEdit(id, text) => {
                     view.input = Some(NoteInput {
                         editing: Some(id),
-                        text,
+                        // Cursor lands at the end, ready for ⌥← to step back
+                        // through the existing name.
+                        text: TextInput::with_text(text),
                     });
                 }
                 NoteCmd::CancelInput => view.input = None,
@@ -5400,6 +5408,124 @@ mod tests {
             "expected notes overlay, got {:?}",
             app.overlay
         );
+    }
+
+    /// Editing a note's text behaves like a terminal line: the caret starts
+    /// at the end, ⌥← (which macOS terminals send as ESC b) walks back a
+    /// word at a time, and typing lands at the caret instead of the tail.
+    #[test]
+    fn note_edit_takes_word_motion_and_inserts_at_the_caret() {
+        use crate::app::NoteView;
+        use nebula_core::{Note, NoteId, NoteOwner, ProjectId};
+        let mut app = App::new();
+        seed_tree(&mut app);
+        let owner = NoteOwner::Project(ProjectId("p1".into()));
+        app.tree.notes.push(Note {
+            id: NoteId("t1".into()),
+            owner: owner.clone(),
+            text: "fix login redirect".into(),
+            done: false,
+            sort_order: 0,
+        });
+        app.overlay = Some(Overlay::Notes(NoteView::new(owner, "demo".into())));
+        let mut out = Vec::new();
+
+        press(&mut app, KeyCode::Enter, KeyModifiers::NONE, &mut out);
+        for _ in 0..2 {
+            press(&mut app, KeyCode::Char('b'), KeyModifiers::ALT, &mut out);
+        }
+        for c in "the ".chars() {
+            press(&mut app, KeyCode::Char(c), KeyModifiers::NONE, &mut out);
+        }
+        let Some(Overlay::Notes(view)) = &app.overlay else {
+            panic!("notes closed")
+        };
+        let input = view.input.as_ref().expect("still editing");
+        assert_eq!(input.text.as_str(), "fix the login redirect");
+
+        out.clear();
+        press(&mut app, KeyCode::Enter, KeyModifiers::NONE, &mut out);
+        assert!(
+            matches!(out.as_slice(), [ClientRequest::UpdateNote { text, .. }] if text == "fix the login redirect"),
+            "Enter saves the edited text, got {out:?}"
+        );
+    }
+
+    /// Backspace on a note being edited deletes a character; it must not
+    /// reach the list's "delete the selected note" binding, and at column 0
+    /// it does nothing at all.
+    #[test]
+    fn note_edit_swallows_backspace_instead_of_deleting_the_note() {
+        use crate::app::NoteView;
+        use nebula_core::{Note, NoteId, NoteOwner, ProjectId};
+        let mut app = App::new();
+        seed_tree(&mut app);
+        let owner = NoteOwner::Project(ProjectId("p1".into()));
+        app.tree.notes.push(Note {
+            id: NoteId("t1".into()),
+            owner: owner.clone(),
+            text: "ab".into(),
+            done: false,
+            sort_order: 0,
+        });
+        app.overlay = Some(Overlay::Notes(NoteView::new(owner, "demo".into())));
+        let mut out = Vec::new();
+        press(&mut app, KeyCode::Enter, KeyModifiers::NONE, &mut out);
+        out.clear();
+        for _ in 0..4 {
+            press(&mut app, KeyCode::Backspace, KeyModifiers::NONE, &mut out);
+        }
+        let Some(Overlay::Notes(view)) = &app.overlay else {
+            panic!("notes closed")
+        };
+        assert_eq!(
+            view.input.as_ref().expect("still editing").text.as_str(),
+            ""
+        );
+        assert!(out.is_empty(), "no DeleteNote leaked out, got {out:?}");
+    }
+
+    /// The always-live search fields edit the same way — and ⌥←/⌥→ move the
+    /// caret rather than typing a literal "b"/"f" into the query.
+    #[test]
+    fn palette_query_edits_like_a_line_and_refilters() {
+        let mut app = App::new();
+        seed_tree(&mut app);
+        let mut out = Vec::new();
+        press(&mut app, KeyCode::Char('/'), KeyModifiers::NONE, &mut out);
+        for c in "demo".chars() {
+            press(&mut app, KeyCode::Char(c), KeyModifiers::NONE, &mut out);
+        }
+        press(&mut app, KeyCode::Char('b'), KeyModifiers::ALT, &mut out);
+        press(&mut app, KeyCode::Char('x'), KeyModifiers::NONE, &mut out);
+        let matched = |app: &App| match &app.overlay {
+            Some(Overlay::Palette(p)) => p.matches.len(),
+            other => panic!("expected palette, got {other:?}"),
+        };
+        let Some(Overlay::Palette(p)) = &app.overlay else {
+            panic!("palette closed")
+        };
+        assert_eq!(p.query.as_str(), "xdemo", "⌥← moves, it does not type 'b'");
+        assert_eq!(matched(&app), 0, "the edit re-ran the filter");
+
+        // Ctrl+W kills the word back to an empty query, which matches all.
+        press(
+            &mut app,
+            KeyCode::Char('e'),
+            KeyModifiers::CONTROL,
+            &mut out,
+        );
+        press(
+            &mut app,
+            KeyCode::Char('w'),
+            KeyModifiers::CONTROL,
+            &mut out,
+        );
+        let Some(Overlay::Palette(p)) = &app.overlay else {
+            panic!("palette closed")
+        };
+        assert_eq!(p.query.as_str(), "");
+        assert!(matched(&app) > 0, "clearing the query restores every row");
     }
 
     /// Resting the worktree selection arms the debounced prewarm; firing it

--- a/crates/nebula-tui/src/lib.rs
+++ b/crates/nebula-tui/src/lib.rs
@@ -13,6 +13,7 @@ pub mod raw_attach;
 pub mod review;
 pub mod splash;
 pub mod syntax;
+pub mod text_input;
 pub mod theme;
 pub mod tree_browser;
 pub mod ui;

--- a/crates/nebula-tui/src/text_input.rs
+++ b/crates/nebula-tui/src/text_input.rs
@@ -1,0 +1,476 @@
+//! One-line text field with the editing keys a terminal user expects.
+//!
+//! Every typed field in the TUI — the note editor, the prompt dialog, the
+//! fuzzy filters, the grep query, the ssh destination — is one of these, so
+//! the keys are learned once and work everywhere: arrows and Home/End,
+//! word motion on ⌥←/⌥→, the readline control chords (Ctrl+A/E/B/F/W/U/K),
+//! and word/line deletes.
+//!
+//! On macOS the option-arrow combos are what actually reaches us as
+//! `Alt+b` / `Alt+f`: both Terminal.app (its bundled keyMappings.plist maps
+//! `~F702`/`~F703` to `ESC b` / `ESC f`) and iTerm2 send the readline word
+//! sequences rather than a modified arrow, so those two chords matter more
+//! than `Alt+Left`/`Alt+Right` — we accept both.
+//!
+//! The field never claims a key an overlay wants for itself: `handle_key`
+//! returns [`Edit::Ignored`] for anything it doesn't recognize, and callers
+//! run it last, after their own bindings have had first refusal.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::fmt;
+use std::ops::Deref;
+
+/// What one key press did to the field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Edit {
+    /// Not an editing key — the caller still owns it.
+    Ignored,
+    /// The cursor moved (or hit an end); the text is unchanged.
+    Moved,
+    /// The text changed — re-run whatever this field feeds.
+    Changed,
+}
+
+impl Edit {
+    /// Did the key belong to the field at all?
+    pub fn consumed(self) -> bool {
+        !matches!(self, Edit::Ignored)
+    }
+
+    /// Does whatever this field drives (a filter, a search, a listing) need
+    /// recomputing?
+    pub fn changed(self) -> bool {
+        matches!(self, Edit::Changed)
+    }
+}
+
+/// Editable single-line text plus a cursor into it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TextInput {
+    text: String,
+    /// Byte offset into `text`; always on a char boundary, always ≤ len.
+    cursor: usize,
+}
+
+/// Word characters for ⌥-arrow / Ctrl+W motion: a run of these is one word,
+/// everything else (spaces, `/`, `-`, `.`) separates. Matches what readline
+/// does in a shell, which is where the muscle memory comes from.
+fn is_word(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+impl TextInput {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A field pre-filled with `text`, cursor parked at the end — the state
+    /// you want when an edit starts from an existing value.
+    pub fn with_text(text: impl Into<String>) -> Self {
+        let text = text.into();
+        let cursor = text.len();
+        Self { text, cursor }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.text
+    }
+
+    /// Cursor as a char offset — the unit the renderer draws in.
+    pub fn cursor_chars(&self) -> usize {
+        self.text[..self.cursor].chars().count()
+    }
+
+    /// Replace the whole value, cursor to the end.
+    pub fn set_text(&mut self, text: impl Into<String>) {
+        self.text = text.into();
+        self.cursor = self.text.len();
+    }
+
+    pub fn clear(&mut self) {
+        self.text.clear();
+        self.cursor = 0;
+    }
+
+    pub fn insert_char(&mut self, c: char) {
+        self.text.insert(self.cursor, c);
+        self.cursor += c.len_utf8();
+    }
+
+    /// Insert a whole run at the cursor — a bracketed paste, minus the
+    /// newlines a one-line field can't hold.
+    pub fn insert_str(&mut self, s: &str) {
+        let flat: String = s
+            .chars()
+            .map(|c| if c == '\n' || c == '\r' { ' ' } else { c })
+            .collect();
+        self.text.insert_str(self.cursor, &flat);
+        self.cursor += flat.len();
+    }
+
+    /// Apply one key press. Returns [`Edit::Ignored`] for anything that
+    /// isn't an editing key, leaving it for the caller.
+    pub fn handle_key(&mut self, key: &KeyEvent) -> Edit {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        // Cmd on macOS, when a terminal delivers it at all: line-wise.
+        let cmd = key
+            .modifiers
+            .intersects(KeyModifiers::SUPER | KeyModifiers::META | KeyModifiers::HYPER);
+
+        match key.code {
+            // ---- motion ----
+            KeyCode::Left if cmd => self.move_to(0),
+            KeyCode::Left if alt || ctrl => self.move_to(self.word_left(self.cursor)),
+            KeyCode::Left => self.move_to(self.prev_boundary(self.cursor)),
+            KeyCode::Right if cmd => self.move_to(self.text.len()),
+            KeyCode::Right if alt || ctrl => self.move_to(self.word_right(self.cursor)),
+            KeyCode::Right => self.move_to(self.next_boundary(self.cursor)),
+            KeyCode::Home => self.move_to(0),
+            KeyCode::End => self.move_to(self.text.len()),
+
+            // ---- deletion ----
+            // Cmd+⌫ kills the line, ⌥⌫ / Ctrl+⌫ the previous word.
+            KeyCode::Backspace if cmd => self.delete(0, self.cursor),
+            KeyCode::Backspace if alt || ctrl => {
+                self.delete(self.word_left(self.cursor), self.cursor)
+            }
+            KeyCode::Backspace => self.delete(self.prev_boundary(self.cursor), self.cursor),
+            KeyCode::Delete if cmd => self.delete(self.cursor, self.text.len()),
+            KeyCode::Delete if alt || ctrl => {
+                self.delete(self.cursor, self.word_right(self.cursor))
+            }
+            KeyCode::Delete => self.delete(self.cursor, self.next_boundary(self.cursor)),
+
+            // ---- readline chords ----
+            // Cmd+key never means "type this" — leave it to the caller.
+            KeyCode::Char(_) if cmd => Edit::Ignored,
+            KeyCode::Char(c) if ctrl => match c.to_ascii_lowercase() {
+                'a' => self.move_to(0),
+                'e' => self.move_to(self.text.len()),
+                'b' => self.move_to(self.prev_boundary(self.cursor)),
+                'f' => self.move_to(self.next_boundary(self.cursor)),
+                'd' => self.delete(self.cursor, self.next_boundary(self.cursor)),
+                'w' => self.delete(self.word_left(self.cursor), self.cursor),
+                'u' => self.delete(0, self.cursor),
+                'k' => self.delete(self.cursor, self.text.len()),
+                _ => Edit::Ignored,
+            },
+            // ⌥b/⌥f are what macOS terminals send for ⌥←/⌥→; ⌥d is
+            // readline's kill-word-forward.
+            KeyCode::Char(c) if alt => match c.to_ascii_lowercase() {
+                'b' => self.move_to(self.word_left(self.cursor)),
+                'f' => self.move_to(self.word_right(self.cursor)),
+                'd' => self.delete(self.cursor, self.word_right(self.cursor)),
+                // Some emulators send ⌥⌫ as ESC + DEL rather than a
+                // modified Backspace key.
+                '\u{7f}' | '\u{8}' => self.delete(self.word_left(self.cursor), self.cursor),
+                _ => Edit::Ignored,
+            },
+
+            // ---- text ----
+            // Plain (or shifted) printable keys, including the glyphs a Mac
+            // makes from ⌥-letters when the profile isn't option-as-meta.
+            KeyCode::Char(c) => {
+                self.insert_char(c);
+                Edit::Changed
+            }
+            _ => Edit::Ignored,
+        }
+    }
+
+    // ---- internals ----
+
+    fn move_to(&mut self, at: usize) -> Edit {
+        self.cursor = at;
+        Edit::Moved
+    }
+
+    fn delete(&mut self, start: usize, end: usize) -> Edit {
+        if start >= end {
+            // Backspace at column 0 is still the field's key — swallow it so
+            // an overlay doesn't read it as "delete the selected row".
+            return Edit::Moved;
+        }
+        self.text.replace_range(start..end, "");
+        self.cursor = start;
+        Edit::Changed
+    }
+
+    fn char_before(&self, at: usize) -> Option<char> {
+        self.text[..at].chars().next_back()
+    }
+
+    fn char_at(&self, at: usize) -> Option<char> {
+        self.text[at..].chars().next()
+    }
+
+    fn prev_boundary(&self, at: usize) -> usize {
+        self.char_before(at).map_or(at, |c| at - c.len_utf8())
+    }
+
+    fn next_boundary(&self, at: usize) -> usize {
+        self.char_at(at).map_or(at, |c| at + c.len_utf8())
+    }
+
+    /// Start of the word at or before `at`: skip back over separators, then
+    /// over the word itself (readline's `backward-word`).
+    fn word_left(&self, mut at: usize) -> usize {
+        while self.char_before(at).is_some_and(|c| !is_word(c)) {
+            at = self.prev_boundary(at);
+        }
+        while self.char_before(at).is_some_and(is_word) {
+            at = self.prev_boundary(at);
+        }
+        at
+    }
+
+    /// End of the word at or after `at` (readline's `forward-word`).
+    fn word_right(&self, mut at: usize) -> usize {
+        while self.char_at(at).is_some_and(|c| !is_word(c)) {
+            at = self.next_boundary(at);
+        }
+        while self.char_at(at).is_some_and(is_word) {
+            at = self.next_boundary(at);
+        }
+        at
+    }
+}
+
+/// Read access is just `&str`, so every `is_empty()` / `chars()` / `trim()`
+/// call site — and every `&str` argument — keeps working unchanged.
+impl Deref for TextInput {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.text
+    }
+}
+
+impl fmt::Display for TextInput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.text)
+    }
+}
+
+impl From<String> for TextInput {
+    fn from(text: String) -> Self {
+        Self::with_text(text)
+    }
+}
+
+impl From<&str> for TextInput {
+    fn from(text: &str) -> Self {
+        Self::with_text(text)
+    }
+}
+
+impl PartialEq<str> for TextInput {
+    fn eq(&self, other: &str) -> bool {
+        self.text == other
+    }
+}
+
+impl PartialEq<&str> for TextInput {
+    fn eq(&self, other: &&str) -> bool {
+        self.text == *other
+    }
+}
+
+impl PartialEq<String> for TextInput {
+    fn eq(&self, other: &String) -> bool {
+        &self.text == other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    /// Type `s` a character at a time, as the event loop would.
+    fn typed(s: &str) -> TextInput {
+        let mut input = TextInput::new();
+        for c in s.chars() {
+            input.handle_key(&key(KeyCode::Char(c), KeyModifiers::NONE));
+        }
+        input
+    }
+
+    fn press(input: &mut TextInput, code: KeyCode, mods: KeyModifiers) -> Edit {
+        input.handle_key(&key(code, mods))
+    }
+
+    #[test]
+    fn typing_appends_and_tracks_the_cursor() {
+        let input = typed("hello");
+        assert_eq!(input.as_str(), "hello");
+        assert_eq!(input.cursor_chars(), 5);
+    }
+
+    #[test]
+    fn arrows_move_and_typing_inserts_at_the_cursor() {
+        let mut input = typed("hello");
+        press(&mut input, KeyCode::Left, KeyModifiers::NONE);
+        press(&mut input, KeyCode::Left, KeyModifiers::NONE);
+        assert_eq!(input.cursor_chars(), 3);
+        assert_eq!(
+            press(&mut input, KeyCode::Char('X'), KeyModifiers::NONE),
+            Edit::Changed
+        );
+        assert_eq!(input.as_str(), "helXlo");
+        assert_eq!(input.cursor_chars(), 4);
+    }
+
+    #[test]
+    fn backspace_deletes_before_the_cursor_only() {
+        let mut input = typed("hello");
+        press(&mut input, KeyCode::Home, KeyModifiers::NONE);
+        press(&mut input, KeyCode::Right, KeyModifiers::NONE);
+        press(&mut input, KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(input.as_str(), "ello");
+        assert_eq!(input.cursor_chars(), 0);
+        // At column 0 it is still the field's key — consumed, not passed on.
+        assert_eq!(
+            press(&mut input, KeyCode::Backspace, KeyModifiers::NONE),
+            Edit::Moved
+        );
+        assert_eq!(input.as_str(), "ello");
+    }
+
+    #[test]
+    fn delete_removes_forward() {
+        let mut input = typed("hello");
+        press(&mut input, KeyCode::Home, KeyModifiers::NONE);
+        press(&mut input, KeyCode::Delete, KeyModifiers::NONE);
+        assert_eq!(input.as_str(), "ello");
+        press(&mut input, KeyCode::Char('d'), KeyModifiers::CONTROL);
+        assert_eq!(input.as_str(), "llo");
+    }
+
+    /// What ⌥← actually sends on macOS: ESC b, i.e. crossterm's Alt+b.
+    #[test]
+    fn option_arrows_arrive_as_alt_b_and_alt_f() {
+        let mut input = typed("fix the login redirect");
+        assert_eq!(
+            press(&mut input, KeyCode::Char('b'), KeyModifiers::ALT),
+            Edit::Moved
+        );
+        assert_eq!(input.cursor_chars(), "fix the login ".len());
+        press(&mut input, KeyCode::Char('b'), KeyModifiers::ALT);
+        assert_eq!(input.cursor_chars(), "fix the ".len());
+        press(&mut input, KeyCode::Char('f'), KeyModifiers::ALT);
+        assert_eq!(input.cursor_chars(), "fix the login".len());
+    }
+
+    #[test]
+    fn alt_and_ctrl_arrows_move_by_word_too() {
+        let mut input = typed("one two three");
+        press(&mut input, KeyCode::Left, KeyModifiers::ALT);
+        assert_eq!(input.cursor_chars(), "one two ".len());
+        press(&mut input, KeyCode::Left, KeyModifiers::CONTROL);
+        assert_eq!(input.cursor_chars(), "one ".len());
+        press(&mut input, KeyCode::Right, KeyModifiers::ALT);
+        assert_eq!(input.cursor_chars(), "one two".len());
+    }
+
+    #[test]
+    fn word_motion_treats_punctuation_as_a_separator() {
+        let mut input = typed("~/src/nebula-tui/app.rs");
+        press(&mut input, KeyCode::Char('b'), KeyModifiers::ALT);
+        assert_eq!(input.cursor_chars(), "~/src/nebula-tui/app.".len());
+        press(&mut input, KeyCode::Char('b'), KeyModifiers::ALT);
+        assert_eq!(input.cursor_chars(), "~/src/nebula-tui/".len());
+    }
+
+    #[test]
+    fn word_and_line_deletes() {
+        let mut input = typed("one two three");
+        assert_eq!(
+            press(&mut input, KeyCode::Char('w'), KeyModifiers::CONTROL),
+            Edit::Changed
+        );
+        assert_eq!(input.as_str(), "one two ");
+        press(&mut input, KeyCode::Backspace, KeyModifiers::ALT);
+        assert_eq!(input.as_str(), "one ");
+        press(&mut input, KeyCode::Char('u'), KeyModifiers::CONTROL);
+        assert_eq!(input.as_str(), "");
+    }
+
+    #[test]
+    fn ctrl_k_kills_to_the_end_and_ctrl_a_e_jump() {
+        let mut input = typed("keep this cut this");
+        press(&mut input, KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert_eq!(input.cursor_chars(), 0);
+        for _ in 0.."keep this ".len() {
+            press(&mut input, KeyCode::Char('f'), KeyModifiers::CONTROL);
+        }
+        press(&mut input, KeyCode::Char('k'), KeyModifiers::CONTROL);
+        assert_eq!(input.as_str(), "keep this ");
+        press(&mut input, KeyCode::Char('e'), KeyModifiers::CONTROL);
+        assert_eq!(input.cursor_chars(), 10);
+    }
+
+    #[test]
+    fn alt_d_kills_the_word_ahead() {
+        let mut input = typed("alpha beta");
+        press(&mut input, KeyCode::Home, KeyModifiers::NONE);
+        press(&mut input, KeyCode::Char('d'), KeyModifiers::ALT);
+        assert_eq!(input.as_str(), " beta");
+    }
+
+    #[test]
+    fn multibyte_text_moves_by_whole_characters() {
+        let mut input = typed("héllo→");
+        press(&mut input, KeyCode::Left, KeyModifiers::NONE);
+        press(&mut input, KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(input.as_str(), "héll→");
+        assert_eq!(input.cursor_chars(), 4);
+    }
+
+    #[test]
+    fn unknown_keys_are_left_to_the_caller() {
+        let mut input = typed("x");
+        assert_eq!(
+            press(&mut input, KeyCode::Enter, KeyModifiers::NONE),
+            Edit::Ignored
+        );
+        assert_eq!(
+            press(&mut input, KeyCode::Esc, KeyModifiers::NONE),
+            Edit::Ignored
+        );
+        assert_eq!(
+            press(&mut input, KeyCode::Tab, KeyModifiers::NONE),
+            Edit::Ignored
+        );
+        assert_eq!(
+            press(&mut input, KeyCode::Up, KeyModifiers::NONE),
+            Edit::Ignored
+        );
+        assert_eq!(
+            press(&mut input, KeyCode::Char('n'), KeyModifiers::CONTROL),
+            Edit::Ignored
+        );
+        assert_eq!(input.as_str(), "x");
+    }
+
+    #[test]
+    fn paste_inserts_at_the_cursor_and_flattens_newlines() {
+        let mut input = typed("ab");
+        press(&mut input, KeyCode::Left, KeyModifiers::NONE);
+        input.insert_str("one\ntwo");
+        assert_eq!(input.as_str(), "aone twob");
+        assert_eq!(input.cursor_chars(), 8);
+    }
+
+    #[test]
+    fn with_text_parks_the_cursor_at_the_end() {
+        let mut input = TextInput::with_text("note");
+        assert_eq!(input.cursor_chars(), 4);
+        press(&mut input, KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(input.as_str(), "not");
+    }
+}

--- a/crates/nebula-tui/src/tree_browser.rs
+++ b/crates/nebula-tui/src/tree_browser.rs
@@ -4,6 +4,7 @@
 
 use crate::app::{DEFAULT_DIFF_FILES_W, MIN_DIFF_FILES_W, MIN_DIFF_PANE_W};
 use crate::syntax::{Highlighter, TokenKind};
+use crate::text_input::TextInput;
 use ratatui::layout::Rect;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -52,7 +53,7 @@ pub struct TreeBrowser {
     /// filter force-expands every hierarchy it keeps.
     pub expanded: Vec<bool>,
     /// Type-to-filter query over file paths; always live.
-    pub filter: String,
+    pub filter: TextInput,
     /// Total file (non-directory) count, for the title.
     pub file_count: usize,
     /// Files matching the filter, for the title.
@@ -105,7 +106,7 @@ impl TreeBrowser {
             nodes,
             top,
             expanded,
-            filter: String::new(),
+            filter: TextInput::new(),
             file_count,
             match_count: file_count,
             rows: Vec::new(),

--- a/crates/nebula-tui/src/ui.rs
+++ b/crates/nebula-tui/src/ui.rs
@@ -5,6 +5,7 @@ use crate::app::{
     App, ConnState, Focus, HitTarget, Overlay, PaletteTarget, ProjectRow, SessionRow,
 };
 use crate::git_diff::{classify_diff_line, DiffLineKind};
+use crate::text_input::TextInput;
 use crate::theme::Theme;
 use nebula_core::{AgentStatus, SessionRef};
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -275,7 +276,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
             // listing between the input and the hint; the dialog grows to
             // fit the listing (at least one row, for the empty message).
             let is_path = prompt.completes_paths();
-            let width = if is_path { 72 } else { 52 };
+            let width = if is_path { 72 } else { 56 };
             let list_h = if is_path {
                 prompt.dirs.len().clamp(1, 8) as u16
             } else {
@@ -309,33 +310,19 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
                 f.render_widget(Paragraph::new(Line::from(spans)), r);
             }
 
-            // Row 1: the input. Long paths show the tail so the cursor
-            // stays visible; the cursor dims while a listing row is
-            // highlighted (Enter takes the highlight, not the text).
+            // Row 1: the input. Long paths scroll under it around the
+            // caret; the caret dims while a listing row is highlighted
+            // (Enter takes the highlight, not the text).
             if let Some(r) = row_rect(inner, 1) {
-                let input_budget = inner.width.saturating_sub(3) as usize;
-                let shown_input: String = if prompt.input.chars().count() > input_budget {
-                    let skip = prompt.input.chars().count() - input_budget;
-                    format!(
-                        "…{}",
-                        prompt.input.chars().skip(skip + 1).collect::<String>()
-                    )
-                } else {
-                    prompt.input.clone()
-                };
+                let budget = inner.width.saturating_sub(2) as usize;
                 let cursor = if prompt.hover.is_some() {
                     th.dim
                 } else {
                     th.text
                 };
-                f.render_widget(
-                    Paragraph::new(Line::from(vec![
-                        Span::raw("> "),
-                        Span::styled(shown_input, Style::default().fg(th.text)),
-                        Span::styled("█", Style::default().fg(cursor)),
-                    ])),
-                    r,
-                );
+                let mut spans = vec![Span::raw("> ")];
+                spans.extend(input_spans(&prompt.input, budget, cursor, th));
+                f.render_widget(Paragraph::new(Line::from(spans)), r);
             }
 
             // The listing: one raised-fill row per directory, a ● on git
@@ -387,7 +374,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
                 let hint = if is_path {
                     "[Enter] add  [↓↑] pick  [→] open  [←] up  [Tab] complete  [Esc] cancel"
                 } else {
-                    "[Enter] ok   [Ctrl+u] clear   [Esc] cancel"
+                    "[Enter] ok  [⌥←→] word  [Ctrl+u] clear  [Esc] cancel"
                 };
                 f.render_widget(
                     Paragraph::new(Span::styled(hint, Style::default().fg(th.dim))),
@@ -438,6 +425,15 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
                         ("d / D", "delete one / delete all"),
                     ],
                 ),
+                (
+                    // Every typed field — names, filters, queries — is the
+                    // same line editor (text_input.rs).
+                    "TYPING IN A FIELD",
+                    &[
+                        ("←→ / ⌥←→", "move by character / by word"),
+                        ("^a^e ⌥⌫ ^u^k", "ends · del word · kill line"),
+                    ],
+                ),
             ];
             const RIGHT: &[HelpSection] = &[
                 (
@@ -472,7 +468,6 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
                         ("s", "settings"),
                         ("M", "memory usage (nebula + agents)"),
                         ("N", "nebula splash (any key returns)"),
-                        ("^u", "clear typed input"),
                         ("q / ?", "quit / toggle this help"),
                     ],
                 ),
@@ -857,14 +852,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
 
             // First row: the always-on fuzzy filter input.
             if let Some(filter_area) = row_rect(files_inner, 0) {
-                let line = if view.filter.is_empty() {
-                    Line::from(Span::styled("type to filter…", Style::default().fg(th.dim)))
-                } else {
-                    Line::from(vec![
-                        Span::raw(view.filter.clone()),
-                        Span::styled("█", Style::default().fg(th.accent)),
-                    ])
-                };
+                let line = search_line(&view.filter, "type to filter…", filter_area, th);
                 f.render_widget(Paragraph::new(line), filter_area);
             }
             let list_inner = Rect {
@@ -1000,14 +988,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
 
             // First row: the always-on fuzzy query input.
             if let Some(query_area) = row_rect(inner, 0) {
-                let line = if palette.query.is_empty() {
-                    Line::from(Span::styled("type to search…", Style::default().fg(th.dim)))
-                } else {
-                    Line::from(vec![
-                        Span::raw(palette.query.clone()),
-                        Span::styled("█", Style::default().fg(th.accent)),
-                    ])
-                };
+                let line = search_line(&palette.query, "type to search…", query_area, th);
                 f.render_widget(Paragraph::new(line), query_area);
             }
             let list_inner = Rect {
@@ -1092,14 +1073,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
 
             // First row: the always-on fuzzy query input.
             if let Some(query_area) = row_rect(inner, 0) {
-                let line = if finder.query.is_empty() {
-                    Line::from(Span::styled("type to filter…", Style::default().fg(th.dim)))
-                } else {
-                    Line::from(vec![
-                        Span::raw(finder.query.clone()),
-                        Span::styled("█", Style::default().fg(th.accent)),
-                    ])
-                };
+                let line = search_line(&finder.query, "type to filter…", query_area, th);
                 f.render_widget(Paragraph::new(line), query_area);
             }
             let list_inner = Rect {
@@ -1180,14 +1154,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
 
             // First row: the always-live grep query.
             if let Some(query_area) = row_rect(inner, 0) {
-                let line = if view.query.is_empty() {
-                    Line::from(Span::styled("type to search…", Style::default().fg(th.dim)))
-                } else {
-                    Line::from(vec![
-                        Span::raw(view.query.clone()),
-                        Span::styled("█", Style::default().fg(th.accent)),
-                    ])
-                };
+                let line = search_line(&view.query, "type to search…", query_area, th);
                 f.render_widget(Paragraph::new(line), query_area);
             }
             let list_inner = Rect {
@@ -1322,22 +1289,10 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
             }
             if let Some(input) = &view.input {
                 if let Some(row_area) = row_rect(inner, total.saturating_sub(start)) {
-                    let budget = (inner.width as usize).saturating_sub(3);
-                    // Long inputs: show the tail so the cursor stays visible.
-                    let shown: String = if input.chars().count() > budget {
-                        let skip = input.chars().count() - budget.saturating_sub(1);
-                        format!("…{}", input.chars().skip(skip).collect::<String>())
-                    } else {
-                        input.clone()
-                    };
-                    f.render_widget(
-                        Paragraph::new(Line::from(vec![
-                            Span::styled("+ ", Style::default().fg(th.accent)),
-                            Span::raw(shown),
-                            Span::styled("█", Style::default().fg(th.accent)),
-                        ])),
-                        row_area,
-                    );
+                    let budget = (inner.width as usize).saturating_sub(2);
+                    let mut spans = vec![Span::styled("+ ", Style::default().fg(th.accent))];
+                    spans.extend(input_spans(input, budget, th.accent, th));
+                    f.render_widget(Paragraph::new(Line::from(spans)), row_area);
                 }
             }
 
@@ -1379,7 +1334,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
                 format!(" Notes — {} (all {total} done) ", view.context)
             };
             let hint = if view.input.is_some() {
-                " Enter: save  Esc: cancel "
+                " Enter: save  ⌥←→: word  Esc: cancel "
             } else {
                 " e: add  Enter: edit  Space: done  d: delete "
             };
@@ -1423,23 +1378,16 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
                 let editing_this =
                     view.input.as_ref().and_then(|inp| inp.editing.as_ref()) == Some(&note.id);
                 let spans = if editing_this {
-                    let text = view
-                        .input
-                        .as_ref()
-                        .map(|inp| inp.text.clone())
-                        .unwrap_or_default();
-                    // Long edits: show the tail so the cursor stays visible.
-                    let shown: String = if text.chars().count() > budget.saturating_sub(1) {
-                        let skip = text.chars().count() - budget.saturating_sub(2);
-                        format!("…{}", text.chars().skip(skip).collect::<String>())
-                    } else {
-                        text
-                    };
-                    vec![
-                        Span::styled("☐ ", Style::default().fg(th.warn)),
-                        Span::raw(shown),
-                        Span::styled("█", Style::default().fg(th.accent)),
-                    ]
+                    let mut spans = vec![Span::styled("☐ ", Style::default().fg(th.warn))];
+                    if let Some(inp) = &view.input {
+                        spans.extend(input_spans(
+                            &inp.text,
+                            budget.saturating_sub(1),
+                            th.accent,
+                            th,
+                        ));
+                    }
+                    spans
                 } else if note.done {
                     vec![
                         Span::styled("✓ ", Style::default().fg(th.ok)),
@@ -1462,26 +1410,12 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
             }
             if creating {
                 if let Some(row_area) = row_rect(inner, screen_row) {
-                    let text = view
-                        .input
-                        .as_ref()
-                        .map(|inp| inp.text.clone())
-                        .unwrap_or_default();
-                    let budget = (inner.width as usize).saturating_sub(3);
-                    let shown: String = if text.chars().count() > budget {
-                        let skip = text.chars().count() - budget.saturating_sub(1);
-                        format!("…{}", text.chars().skip(skip).collect::<String>())
-                    } else {
-                        text
-                    };
-                    f.render_widget(
-                        Paragraph::new(Line::from(vec![
-                            Span::styled("+ ", Style::default().fg(th.accent)),
-                            Span::raw(shown),
-                            Span::styled("█", Style::default().fg(th.accent)),
-                        ])),
-                        row_area,
-                    );
+                    let budget = (inner.width as usize).saturating_sub(2);
+                    let mut spans = vec![Span::styled("+ ", Style::default().fg(th.accent))];
+                    if let Some(inp) = &view.input {
+                        spans.extend(input_spans(&inp.text, budget, th.accent, th));
+                    }
+                    f.render_widget(Paragraph::new(Line::from(spans)), row_area);
                 }
             }
 
@@ -1521,14 +1455,7 @@ fn draw_overlay(f: &mut Frame, app: &mut App) {
 
             // First row: the always-on fuzzy filter input.
             if let Some(filter_area) = row_rect(tree_inner, 0) {
-                let line = if view.filter.is_empty() {
-                    Line::from(Span::styled("type to filter…", Style::default().fg(th.dim)))
-                } else {
-                    Line::from(vec![
-                        Span::raw(view.filter.clone()),
-                        Span::styled("█", Style::default().fg(th.accent)),
-                    ])
-                };
+                let line = search_line(&view.filter, "type to filter…", filter_area, th);
                 f.render_widget(Paragraph::new(line), filter_area);
             }
             let list_inner = Rect {
@@ -3026,6 +2953,74 @@ fn fuzzy_highlight_spans(shown: &str, positions: &[usize], th: Theme) -> Vec<Spa
     spans
 }
 
+/// Spans for a one-line text field: the value with a block cursor sitting
+/// where the caret is. Long values scroll under the field — the window
+/// keeps the caret near the middle, and a `…` marks each end that has text
+/// scrolled off it.
+///
+/// `cursor` colors the caret block; pass `th.dim` to park it (the prompt
+/// does that while a listing row, not the text, holds Enter).
+fn input_spans(input: &TextInput, budget: usize, cursor: Color, th: Theme) -> Vec<Span<'static>> {
+    let chars: Vec<char> = input.chars().collect();
+    let caret = input.cursor_chars();
+    let budget = budget.max(1);
+    // A caret parked past the last character needs one extra cell to sit in.
+    let total = chars.len() + usize::from(caret >= chars.len());
+    let start = if total <= budget {
+        0
+    } else {
+        caret.saturating_sub(budget / 2).min(total - budget)
+    };
+    let end = (start + budget).min(total);
+
+    let mut cells: Vec<(char, bool)> = (start..end)
+        .map(|i| (chars.get(i).copied().unwrap_or(' '), i == caret))
+        .collect();
+    // The window is centered on the caret, so an elided edge is never the
+    // caret's own cell.
+    if start > 0 {
+        if let Some(first) = cells.first_mut() {
+            first.0 = '…';
+        }
+    }
+    if end < total {
+        if let Some(last) = cells.last_mut() {
+            last.0 = '…';
+        }
+    }
+
+    let plain = Style::default().fg(th.text);
+    let block = Style::default().fg(th.on_accent).bg(cursor);
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut run = String::new();
+    let mut run_is_caret = false;
+    for (c, is_caret) in cells {
+        if is_caret != run_is_caret && !run.is_empty() {
+            let style = if run_is_caret { block } else { plain };
+            spans.push(Span::styled(std::mem::take(&mut run), style));
+        }
+        run_is_caret = is_caret;
+        run.push(c);
+    }
+    if !run.is_empty() {
+        let style = if run_is_caret { block } else { plain };
+        spans.push(Span::styled(run, style));
+    }
+    spans
+}
+
+/// The always-live search row every fuzzy overlay shares: a dim placeholder
+/// until something is typed, then the field itself.
+fn search_line(input: &TextInput, placeholder: &str, area: Rect, th: Theme) -> Line<'static> {
+    if input.is_empty() {
+        return Line::from(Span::styled(
+            placeholder.to_string(),
+            Style::default().fg(th.dim),
+        ));
+    }
+    Line::from(input_spans(input, area.width as usize, th.accent, th))
+}
+
 /// The i-th single-height row inside `inner`, or None when it overflows.
 fn row_rect(inner: Rect, i: usize) -> Option<Rect> {
     rows_rect(inner, i, 1)
@@ -3078,11 +3073,67 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     const RAMP: [Color; 3] = [Color::Yellow, Color::Indexed(220), Color::Indexed(230)];
 
     fn colors(spans: &[Span]) -> Vec<Color> {
         spans.iter().map(|s| s.style.fg.unwrap()).collect()
+    }
+
+    /// Render an input the way the widgets do, marking the caret cell with
+    /// `[]` so placement is readable in an assertion.
+    fn rendered(input: &TextInput, budget: usize) -> String {
+        let th = Theme::default();
+        input_spans(input, budget, th.accent, th)
+            .iter()
+            .map(|s| {
+                if s.style.bg == Some(th.accent) {
+                    format!("[{}]", s.content)
+                } else {
+                    s.content.to_string()
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn caret_sits_past_the_last_character_by_default() {
+        let input = TextInput::with_text("note");
+        assert_eq!(rendered(&input, 20), "note[ ]");
+    }
+
+    #[test]
+    fn caret_renders_in_place_mid_string() {
+        let mut input = TextInput::with_text("note");
+        for _ in 0..2 {
+            input.handle_key(&KeyEvent::new(KeyCode::Left, KeyModifiers::NONE));
+        }
+        assert_eq!(rendered(&input, 20), "no[t]e");
+    }
+
+    /// A value longer than the field scrolls under it, keeping the caret in
+    /// view with a `…` on whichever end is clipped.
+    #[test]
+    fn long_values_scroll_around_the_caret() {
+        let input = TextInput::with_text("abcdefghijklmnop");
+        // Caret at the end: the tail is shown, the head elided.
+        assert_eq!(rendered(&input, 8), "…klmnop[ ]");
+        let mut input = input;
+        input.handle_key(&KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        // Caret at the start: the head is shown, the tail elided.
+        assert_eq!(rendered(&input, 8), "[a]bcdefg…");
+    }
+
+    #[test]
+    fn empty_search_fields_show_their_placeholder() {
+        let th = Theme::default();
+        let area = Rect::new(0, 0, 20, 1);
+        let line = search_line(&TextInput::new(), "type to filter…", area, th);
+        assert_eq!(line.spans[0].content.as_ref(), "type to filter…");
+        let line = search_line(&TextInput::with_text("ab"), "type to filter…", area, th);
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "ab ");
     }
 
     /// The sweep must recolor cells without ever changing what they spell.


### PR DESCRIPTION
## What

Every typed field in the TUI — note names, the prompt dialog, the fuzzy filters (diff, tree, palette, file finder), the grep query, the ssh destination — tracked a bare `String` and was append-only. There was no caret, `←`/`→` did nothing, and **⌥← typed a literal `b` into the field** instead of stepping back a word (macOS terminals send ⌥←/⌥→ as `ESC b` / `ESC f` — Terminal.app's bundled `keyMappings.plist` maps `~F702`/`~F703` to exactly that, and iTerm2 does the same).

All eight fields now share one `TextInput` (text + caret) in the new `crates/nebula-tui/src/text_input.rs`.

## Keys

| | |
|---|---|
| `←→` / `⌥←→` / `^b` `^f` | char and word motion |
| `Home`/`End` / `^a` `^e` | line start / end |
| `⌫` / `⌦` | delete around the caret |
| `⌥⌫` `^w` / `⌥⌦` `⌥d` | delete a word either side |
| `^u` / `^k` | kill to line start / end |

Word motion splits on punctuation, so `⌥←` in a path walks it a segment at a time.

## No bindings were stolen

`handle_key` returns `Edit::Ignored` for anything it doesn't own, and each overlay runs it **last**, after its own arms. So:

- the tree browser's `←`/`→` still fold/unfold
- the add-project prompt's `←`/`→` still ascend/dive the directory listing (the one place they were already spoken for — caret motion there is `⌥←→`, `^b`/`^f`, `Home`/`End`)
- `^d`/`^u` still half-page the diff and tree views **when nothing is typed**; with a live filter `^u` is the line editor's kill-to-start (identical to the old "clear" when the caret is at the end, which it usually is)
- `^n`/`^p`/`^o`/`^f`/`^y` in the palette, finder and tree are untouched

Bracketed paste now lands in the focused field instead of falling through to the terminal pane.

## Rendering

The block cursor draws **in place** rather than always at the tail, and a value longer than its field scrolls under it with a `…` on whichever end is clipped (previously long values just showed their tail). One `input_spans` helper replaced eight copies of the old `text + "█"` snippet.

Help gained a `TYPING IN A FIELD` section; the note and non-path prompt hints mention `⌥←→`.

## Testing

- 14 unit tests on `TextInput` (motion, deletes, multibyte, "⌥← arrives as Alt+b", unknown keys pass through)
- 4 render tests on caret placement and scroll-window ellipsis
- 3 event-loop tests driving the real overlays: editing a note with `⌥←` + insert-at-caret, `⌫` in a note edit not leaking to the list's delete-note binding, and `⌥←`/`^w` in the palette query re-running the filter
- `cargo test --workspace` green (e2e included); `cargo fmt` / `clippy` clean on touched files
- Verified live in tmux: after two `⌥←` the caret block sits on the `l` of "login" (`fg 0 / bg 6`) and typing inserts there

🤖 Generated with [Claude Code](https://claude.com/claude-code)