### PR TITLE
Name the agents nebula actually runs in the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # nebula
 
-A fast, low-memory terminal multiplexer for managing Claude Code agents across
-projects and git worktrees. Think tmux ergonomics with a mission-control-style
-agent manager — entirely inside your terminal.
+A fast, low-memory terminal multiplexer for running coding agents (`claude`,
+`codex`, `cursor-agent`) across your projects and git worktrees. Think tmux
+ergonomics with a mission-control-style agent manager — entirely inside your
+terminal.
 
 ```
 ┌ Projects ─┬ Worktrees ─┬ Sessions ────┬ Terminal ──────────────────────┐


### PR DESCRIPTION
## What

Reworded the README hero tagline.

**Before:** A fast, low-memory terminal multiplexer for managing Claude Code agents across projects and git worktrees.

**After:** A fast, low-memory terminal multiplexer for running coding agents (`claude`, `codex`, `cursor-agent`) across your projects and git worktrees.

## Why

The old line undersold the tool and contradicted the Getting Started section eight lines below, which already tells you to have `claude`, `codex`, or `cursor-agent` on your `PATH`. Naming the binaries up front lets a visitor confirm their agent is supported without reading further.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)