### PR TITLE
Mention Codex and Cursor agent support in README intro

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,6 @@ Worktrees also carry a **link list**: URLs pinned to a checkout — the pull req
 | `nebula-daemon` | PTYs, SQLite, git, hook receiver, status engine |
 | `nebula-tui` | ratatui UI, keyboard/mouse, attach/scrollback |
 
-The TUI also has extras on top of the multiplexer: git diff viewer, grep, a vim-like terminal overlay, fuzzy finders — those are client-side. The daemon is the source of truth for sessions and the tree.
+The TUI also has extras on top of the multiplexer: git diff viewer, file preview, grep, a vim-like terminal overlay, fuzzy finders — those are client-side. The daemon is the source of truth for sessions and the tree.
 
 **Mental model:** tmux, but the “windows” are agent CLIs bound to git worktrees, and the sidebar is a mission-control view of which agents are working, waiting, or dead.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # nebula
 
-A fast, low-memory terminal multiplexer for managing Claude Code agents across
-projects and git worktrees. Think tmux ergonomics with a mission-control-style
-agent manager — entirely inside your terminal.
+A fast, low-memory terminal multiplexer for managing Claude Code, Codex, and
+Cursor agents across projects and git worktrees. Think tmux ergonomics with a
+mission-control-style agent manager — entirely inside your terminal.
 
 ```
 ┌ Projects ─┬ Worktrees ─┬ Sessions ────┬ Terminal ──────────────────────┐


### PR DESCRIPTION
## Summary
- Update the README intro line to name Codex and Cursor agents alongside Claude Code, matching the "Getting started" section below which already lists `claude`, `codex`, and `cursor-agent`.

## Test plan
- N/A (docs-only change)