### PR TITLE
Credit Codex and Cursor in the README tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # nebula
 
-A fast, low-memory terminal multiplexer for managing Claude Code agents across
-projects and git worktrees. Think tmux ergonomics with a mission-control-style
-agent manager — entirely inside your terminal.
+A fast, low-memory terminal multiplexer for managing coding agents (Claude
+Code, Codex, and Cursor) across projects and git worktrees. Think tmux
+ergonomics with a mission-control-style agent manager — entirely inside your
+terminal.
 
 ```
 ┌ Projects ─┬ Worktrees ─┬ Sessions ────┬ Terminal ──────────────────────┐


### PR DESCRIPTION
## What

The README's opening line called nebula a multiplexer for **"Claude Code agents"**, which undersells it — `AgentKind` has three variants (`Claude`, `Codex`, `Cursor`), and the rest of the README already documents spawning all three (`claude`, `codex`, `cursor-agent`).

Reworded to name all three up front.

```diff
-A fast, low-memory terminal multiplexer for managing Claude Code agents across
-projects and git worktrees. Think tmux ergonomics with a mission-control-style
-agent manager — entirely inside your terminal.
+A fast, low-memory terminal multiplexer for managing coding agents (Claude
+Code, Codex, and Cursor) across projects and git worktrees. Think tmux
+ergonomics with a mission-control-style agent manager — entirely inside your
+terminal.
```

## Notes

Docs only — no code touched, so no test run was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)