### PR TITLE
Add Linux clipboard support to copy_to_clipboard

### DIFF
--- a/crates/nebula-tui/src/event_loop.rs
+++ b/crates/nebula-tui/src/event_loop.rs
@@ -4690,18 +4690,25 @@ fn select_word_at(app: &mut App, cell: (u16, u16)) {
     copy_selection(app);
 }
 
-/// Copy to the system clipboard via pbcopy (this tool targets macOS).
+/// Copy to the system clipboard.
+/// macOS: pbcopy. Linux: wl-copy on Wayland, xclip (or xsel) on X11.
 fn copy_to_clipboard(text: &str) -> bool {
     // Unit tests exercise the selection flow; don't clobber the developer's
     // real clipboard from `cargo test`.
     if cfg!(test) {
         return true;
     }
-    #[cfg(target_os = "macos")]
-    {
-        use std::io::Write as _;
-        use std::process::{Command, Stdio};
-        let Ok(mut child) = Command::new("pbcopy").stdin(Stdio::piped()).spawn() else {
+
+    use std::io::Write as _;
+    use std::process::{Command, Stdio};
+
+    let copy_via = |cmd: &str, args: &[&str]| -> bool {
+        let Ok(mut child) = Command::new(cmd)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
             return false;
         };
         let wrote = child
@@ -4709,11 +4716,23 @@ fn copy_to_clipboard(text: &str) -> bool {
             .take()
             .is_some_and(|mut stdin| stdin.write_all(text.as_bytes()).is_ok());
         wrote && child.wait().is_ok_and(|status| status.success())
+    };
+
+    #[cfg(target_os = "macos")]
+    {
+        return copy_via("pbcopy", &[]);
     }
+
     #[cfg(not(target_os = "macos"))]
     {
-        let _ = text;
-        false
+        if std::env::var_os("WAYLAND_DISPLAY").is_some() {
+            return copy_via("wl-copy", &[]);
+        }
+        // X11: prefer xclip, fall back to xsel
+        if copy_via("xclip", &["-selection", "clipboard"]) {
+            return true;
+        }
+        copy_via("xsel", &["--clipboard", "--input"])
     }
 }
 


### PR DESCRIPTION
`copy_to_clipboard` only supports macOS (`pbcopy`); on every other OS it returns `false` unconditionally, so drag-select copy, select+copy mode, and `Ctrl+y` path copy all flash `copy failed (clipboard unavailable)` on Linux.

This PR shells out to the platform clipboard utility instead:

- `wl-copy` when `WAYLAND_DISPLAY` is set (Wayland)
- `xclip -selection clipboard` (X11, most common)
- `xsel --clipboard --input` (X11 fallback)

Same spawn/pipe pattern as the existing `pbcopy` path.

**Verified** on Linux X11 (Ubuntu 24.04, patched v0.3.0 build): drag-selected text lands in the system clipboard; readback via `xclip -o` matches. The standalone spawn/pipe logic was also verified in isolation.

Fixes #9

Note: terminals like Tabby do not handle OSC 52, so shelling out to a clipboard utility is the only mechanism that works everywhere.
