### PR TITLE
Give panel focus the vim keys (h/l), move ssh hosts and links to Shift

### DIFF
--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -14,6 +14,31 @@ about what is worth recording.
 
 ## Entries
 
+### h/l Move Between Panels (Issue #8) — 2026-08-24
+
+**Asked:** "work on https://github.com/AgentSystemLabs/nebula/issues/8 in a worktree make pr when done,
+move notes and links to other hotkeys, but h and l should be for left and right" — issue #8 asks for the
+vim pairing, since `h`/`l` opened the ssh hosts picker and the add-link prompt instead.
+
+**Did:** Four `defaults:` arrays in `crates/nebula-tui/src/keymap.rs` — `focus_left` → `["h", "left"]`,
+`focus_right` → `["l", "right"]`, `hosts` → `["shift+h"]`, `new_link` → `["shift+l"]`. No dispatch code
+changed. New test `h_and_l_walk_panel_focus_like_the_arrows` in `event_loop.rs`; the hosts and link tests
+(8 unit + 3 in `crates/nebula/tests/e2e_tui.rs`) now drive `⇧H`/`⇧L`. PR #12 off `worktree-hl-panel-nav`.
+
+**Gotchas:**
+- The user said "move **notes** and links", but notes is `e` and never conflicted — the two actions
+  actually sitting on `h`/`l` were **hosts** and links. Read the issue, not just the prompt.
+- **Never bulk-replace `Char('h')`/`Char('l')` in `event_loop.rs`.** Most hits are overlay-local grammar
+  the keymap doesn't own and must not change: settings tab/value cycling (~3495-3514), the diff and tree
+  browsers (~2919, ~2960-2966). Only the *test* presses needed swapping.
+- Footer and Help hints come from `Keymap::first(action)`, so **the chord you want displayed has to lead
+  the `defaults:` list** — `["h", "left"]` shows `h`, `["left", "h"]` would still show `←`.
+- Changing a default is safe for existing users: `Keymap::overrides()` (keymap.rs:860) persists only rows
+  that differ from `defaults`, so an untouched action picks the new key up on upgrade while anyone who
+  rebound it keeps theirs.
+- `defaults_do_not_collide_within_a_scope` is the guard for this kind of edit — it fails loudly if a new
+  default double-books a chord in the same `Scope`.
+
 ### The Version Nameplate In The Footer's Left Edge — 2026-08-24
 
 **Asked:** "display the version number of nebula in the bottom bar somewhere, I think bottom left should

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ three, every time, and read the screens.
 
 nebula replaces that with a tree and a color:
 
-- **Every project, worktree and agent in one list.** Four columns, `j`/`k` to move, `Enter` to drill in.
+- **Every project, worktree and agent in one list.** Four columns, `h`/`j`/`k`/`l` to move, `Enter` to drill in.
 - **A dot per session that says what it's doing.** ● yellow is mid-turn, ● green is done, ● red wants
   you. Parents roll up their children, so a red dot on a collapsed project tells you exactly where to
   look without opening anything.
@@ -77,7 +77,8 @@ nebula
 ```
 
 Four columns, left to right: **Projects → Worktrees → Sessions → Terminal**. `Tab` / `Shift+Tab` (or
-`←` / `→`) move focus between columns, `j` / `k` move the selection inside one, and `Enter` drills in.
+`h` / `l`, or `←` / `→`) move focus between columns, `j` / `k` move the selection inside one, and `Enter`
+drills in.
 With no projects yet you get the splash instead — press `n` to add one without leaving the TUI.
 
 **3. Choose where the agent runs.** Select your project, then a worktree. Every project starts with one:
@@ -210,8 +211,8 @@ Defaults — every one of them is rebindable in Settings → Hotkeys (`s`).
 
 | Context | Key | Action |
 |---|---|---|
-| Panels | `Tab`/`Shift+Tab`, `←/→`, `j/k` | move focus / selection |
-| Panels | `Ctrl+→` | cross into the terminal pane without attaching (plain `→` stops at Sessions) |
+| Panels | `Tab`/`Shift+Tab`, `h/l` or `←/→`, `j/k` | move focus / selection |
+| Panels | `Ctrl+→` | cross into the terminal pane without attaching (plain `l`/`→` stops at Sessions) |
 | Panels | `Enter` | drill in; on a session: attach |
 | Any panel | `/` | fuzzy jump across every project, worktree and session (`Ctrl+n/p` move, `Ctrl+o` opens the hit, `Ctrl+f` just lands the selection on it) |
 | Projects | `n` / `d` | add project / remove from list |
@@ -232,11 +233,11 @@ Defaults — every one of them is rebindable in Settings → Hotkeys (`s`).
 | Any panel | `g` | git diff for the selected worktree: filter, `↑↓` files, `Shift+↑↓`/`PgUp/PgDn`/`Ctrl+d/u` scroll, `Ctrl+r` marks a file reviewed ✓ |
 | Any panel | `Shift+G` | open the selected repo's page on its git host — the `origin` remote (`git@github.com:o/r.git`, `ssh://`, `https://`) turned into a browsable URL, credentials stripped |
 | Any panel | `f` / `F` / `b` | find file / find in files (`git grep`) / file tree browser, all scoped to the selected worktree — `Enter` opens the file in an editor modal (at the matched line, for `F`); in `f` and `b`, `Ctrl+y` copies the path |
-| Any panel | `l` | attach a link (pull request, doc, ticket) to the selected worktree — it lands in the Sessions panel's LINKS group, above any open pull request nebula finds with `gh` |
+| Any panel | `Shift+L` | attach a link (pull request, doc, ticket) to the selected worktree — it lands in the Sessions panel's LINKS group, above any open pull request nebula finds with `gh` |
 | Sessions | `Enter` / `r` / `d` on a link | open it in the browser / edit its URL / delete it (the detected pull request opens but can't be edited or deleted) |
 | Any panel | `t` | new shell terminal in the selected worktree's directory (Projects panel: the repo root) |
 | Any panel | `w` | workspace switcher: `Enter` opens, `n`/`r`/`d` create/rename/delete (the open workspace shows bottom-left; `/` and the panels scope to it). Per window — switching here leaves your other nebula instances on the workspace you left them on |
-| Any panel | `h` | ssh hosts: every `nebula ssh` destination, newest first. `Enter`/click reconnects (quits this TUI and execs a fresh `nebula ssh` — local sessions keep running), `a` types a new `user@host [dir]`, `d` removes |
+| Any panel | `Shift+H` | ssh hosts: every `nebula ssh` destination, newest first. `Enter`/click reconnects (quits this TUI and execs a fresh `nebula ssh` — local sessions keep running), `a` types a new `user@host [dir]`, `d` removes |
 | Any panel | `m` or right-click | context menu |
 | Any panel | `z` | full-screen terminal: collapse the sidebars and lock input into the attached session |
 | Any panel | `s` | settings overlay (theme, editor, agent defaults, timeouts) — its Hotkeys tab rebinds every key in this table |

--- a/crates/nebula-tui/src/event_loop.rs
+++ b/crates/nebula-tui/src/event_loop.rs
@@ -1810,7 +1810,7 @@ fn open_notes_for_owner(app: &mut App, owner: NoteOwner) {
     app.overlay = Some(Overlay::Notes(NoteView::new(owner, context)));
 }
 
-/// `h`: destinations remembered by `nebula ssh`, newest first. Opens even
+/// `Shift+H`: destinations remembered by `nebula ssh`, newest first. Opens even
 /// when empty — the modal's hint is how the feature introduces itself.
 fn open_hosts_picker(app: &mut App) {
     app.overlay = Some(Overlay::Hosts(crate::app::HostsView::new(
@@ -6996,13 +6996,48 @@ mod tests {
             .expect("link row");
     }
 
+    /// `h`/`l` are the vim twins of `←`/`→`: same focus walk, same stops at
+    /// the ends. The plain letters used to open the hosts picker and the
+    /// add-link prompt, which now live on the shifted keys.
     #[test]
-    fn l_adds_a_link_to_the_selected_worktree() {
+    fn h_and_l_walk_panel_focus_like_the_arrows() {
+        let mut app = App::new();
+        let mut out = Vec::new();
+        let l = |app: &mut App, out: &mut Vec<ClientRequest>| {
+            press(app, KeyCode::Char('l'), KeyModifiers::NONE, out)
+        };
+        let h = |app: &mut App, out: &mut Vec<ClientRequest>| {
+            press(app, KeyCode::Char('h'), KeyModifiers::NONE, out)
+        };
+
+        app.focus = Focus::Projects;
+        l(&mut app, &mut out);
+        assert_eq!(app.focus, Focus::Worktrees);
+        l(&mut app, &mut out);
+        assert_eq!(app.focus, Focus::Sessions);
+        l(&mut app, &mut out);
+        assert_eq!(app.focus, Focus::Sessions, "stops at sessions, as → does");
+        assert!(
+            app.overlay.is_none(),
+            "l no longer opens the add-link prompt"
+        );
+
+        h(&mut app, &mut out);
+        assert_eq!(app.focus, Focus::Worktrees);
+        h(&mut app, &mut out);
+        assert_eq!(app.focus, Focus::Projects);
+        h(&mut app, &mut out);
+        assert_eq!(app.focus, Focus::Projects, "stops at projects, as ← does");
+        assert!(app.overlay.is_none(), "h no longer opens the hosts picker");
+    }
+
+    #[test]
+    fn shift_l_adds_a_link_to_the_selected_worktree() {
         let mut app = App::new();
         seed_tree(&mut app);
         app.focus = Focus::Sessions;
         let mut out = Vec::new();
-        press(&mut app, KeyCode::Char('l'), KeyModifiers::NONE, &mut out);
+        press(&mut app, KeyCode::Char('L'), KeyModifiers::SHIFT, &mut out);
         let Some(Overlay::Prompt(p)) = &app.overlay else {
             panic!("expected the add-link prompt, got {:?}", app.overlay);
         };
@@ -15799,13 +15834,16 @@ diff --git a/src/b.rs b/src/b.rs
     }
 
     #[test]
-    fn h_opens_hosts_picker_newest_first() {
+    fn shift_h_opens_hosts_picker_newest_first() {
         with_seeded_hosts(|| {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             let Some(Overlay::Hosts(view)) = &app.overlay else {
-                panic!("h should open the hosts picker, got {:?}", app.overlay);
+                panic!(
+                    "shift+h should open the hosts picker, got {:?}",
+                    app.overlay
+                );
             };
             assert_eq!(view.hosts.len(), 2);
             assert_eq!(view.hosts[0].host, "new@two", "most recent first");
@@ -15832,7 +15870,7 @@ diff --git a/src/b.rs b/src/b.rs
         with_seeded_hosts(|| {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             press(&mut app, KeyCode::Char('j'), KeyModifiers::NONE, &mut out);
             press(&mut app, KeyCode::Enter, KeyModifiers::NONE, &mut out);
             assert!(app.should_quit, "Enter hands off by quitting");
@@ -15848,7 +15886,7 @@ diff --git a/src/b.rs b/src/b.rs
         with_seeded_hosts(|| {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             press(&mut app, KeyCode::Char('d'), KeyModifiers::NONE, &mut out);
             match &app.overlay {
                 Some(Overlay::Hosts(view)) => {
@@ -15869,7 +15907,7 @@ diff --git a/src/b.rs b/src/b.rs
         with_seeded_hosts(|| {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             // Draw once so the modal writes back its hit-test rects.
             let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
             terminal.draw(|f| ui::draw(f, &mut app)).unwrap();
@@ -15893,7 +15931,7 @@ diff --git a/src/b.rs b/src/b.rs
             // Reopened, a click outside the modal closes it.
             app.should_quit = false;
             app.pending_ssh = None;
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             terminal.draw(|f| ui::draw(f, &mut app)).unwrap();
             handle_mouse(
                 &mut app,
@@ -15910,7 +15948,7 @@ diff --git a/src/b.rs b/src/b.rs
         with_seeded_hosts(|| {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             press(&mut app, KeyCode::Char('a'), KeyModifiers::NONE, &mut out);
             // While typing, list verbs are just characters — q must not
             // close, d must not delete.
@@ -15943,7 +15981,7 @@ diff --git a/src/b.rs b/src/b.rs
         with_seeded_hosts(|| {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             press(&mut app, KeyCode::Char('a'), KeyModifiers::NONE, &mut out);
             press(&mut app, KeyCode::Enter, KeyModifiers::NONE, &mut out);
             match &app.overlay {
@@ -15970,7 +16008,7 @@ diff --git a/src/b.rs b/src/b.rs
         crate::hosts::with_hosts_path(path, || {
             let mut app = App::new();
             let mut out = Vec::new();
-            press(&mut app, KeyCode::Char('h'), KeyModifiers::NONE, &mut out);
+            press(&mut app, KeyCode::Char('H'), KeyModifiers::SHIFT, &mut out);
             assert!(matches!(app.overlay, Some(Overlay::Hosts(_))));
             let mut terminal = Terminal::new(TestBackend::new(100, 30)).unwrap();
             terminal.draw(|f| ui::draw(f, &mut app)).unwrap();

--- a/crates/nebula-tui/src/keymap.rs
+++ b/crates/nebula-tui/src/keymap.rs
@@ -136,7 +136,7 @@ pub const ACTIONS: &[ActionSpec] = &[
         hint: "Move focus one panel left (stops at projects)",
         group: "NAVIGATE",
         scope: Scope::Global,
-        defaults: &["left"],
+        defaults: &["h", "left"],
     },
     ActionSpec {
         action: Action::FocusRight,
@@ -145,7 +145,7 @@ pub const ACTIONS: &[ActionSpec] = &[
         hint: "Move focus one panel right (stops at sessions — Enter enters the pane)",
         group: "NAVIGATE",
         scope: Scope::Global,
-        defaults: &["right"],
+        defaults: &["l", "right"],
     },
     ActionSpec {
         action: Action::FocusTerminal,
@@ -291,7 +291,7 @@ pub const ACTIONS: &[ActionSpec] = &[
         hint: "Pin a PR, doc or ticket URL alongside the sessions",
         group: "SESSIONS",
         scope: Scope::Global,
-        defaults: &["l"],
+        defaults: &["shift+l"],
     },
     ActionSpec {
         action: Action::Rename,
@@ -420,7 +420,7 @@ pub const ACTIONS: &[ActionSpec] = &[
         hint: "Connect to a saved ssh host (restarts nebula over ssh)",
         group: "GENERAL",
         scope: Scope::Global,
-        defaults: &["h"],
+        defaults: &["shift+h"],
     },
     ActionSpec {
         action: Action::Settings,

--- a/crates/nebula/tests/e2e_tui.rs
+++ b/crates/nebula/tests/e2e_tui.rs
@@ -635,8 +635,8 @@ fn tui_link_crud_in_sessions_panel() {
     // The root worktree row must exist before a link has an owner.
     tui.wait_for_text("⌂ root");
 
-    // ---- create: l prompts, the URL lands in a LINKS group ----
-    tui.send(b"l");
+    // ---- create: Shift+L prompts, the URL lands in a LINKS group ----
+    tui.send(b"L");
     tui.wait_for_text("Add link");
     tui.type_str("https://example.dev/spec");
     tui.send(b"\r");
@@ -654,7 +654,7 @@ fn tui_link_crud_in_sessions_panel() {
     tui.wait_for_text("example.dev/spec/v2");
 
     // ---- a second link: both list under the one header ----
-    tui.send(b"l");
+    tui.send(b"L");
     tui.wait_for_text("Add link");
     // Typed without a scheme — the daemon normalizes it to https://.
     // Short on purpose: the Sessions panel truncates long rows.
@@ -709,7 +709,7 @@ fn tui_pull_request_row_leads_the_links_group() {
     tui.wait_for_text("can't be deleted");
 
     // A link the user adds lands under it.
-    tui.send(b"l");
+    tui.send(b"L");
     tui.wait_for_text("Add link");
     tui.type_str("example.dev/spec");
     tui.send(b"\r");


### PR DESCRIPTION
Closes #8.

`h` / `l` now move focus between the four panels — the horizontal twins of the `j` / `k` already bound to selection. The arrow keys keep working exactly as before; `h` and `l` are **added** to `focus_left` / `focus_right`, nothing was taken away.

The two actions that were sitting on those letters move onto the shifted keys:

| Action | Was | Now |
|---|---|---|
| Focus left / right | `←` `→` | `h` `←` / `l` `→` |
| SSH hosts | `h` | `⇧H` |
| Attach a link | `l` | `⇧L` |

Both `⇧H` and `⇧L` were free.

### Notes

- The letter leads each default list, so the footer hints and the Help overlay — which are spelled from the live keymap — now show `h` / `l` for the focus walk, and `⇧H` / `⇧L` for hosts and links, with no extra edits.
- Only *defaults* changed. The config persists overrides rather than the whole table (`Keymap::overrides`), so anyone who had already rebound `hosts` or `new_link` keeps their binding, and everyone else picks these up on upgrade. Every key here is still rebindable in Settings → Hotkeys.
- `h` / `l` inside overlays (settings tabs, the diff viewer, the tree browser) are overlay-local grammar and are untouched.

### Verification

- New unit test `h_and_l_walk_panel_focus_like_the_arrows` covers the full walk in both directions plus the stops at Projects and Sessions, and asserts neither key opens an overlay any more.
- The existing hosts-picker and link tests now drive `⇧H` / `⇧L`, including the three `e2e_tui` PTY tests.
- `defaults_do_not_collide_within_a_scope` still passes, so the new defaults are conflict-free.
- `cargo test --workspace`, `cargo fmt --check` and `cargo clippy --workspace --all-targets` are clean (clippy warnings present are pre-existing on `main`).
- README keymap table and the two prose mentions updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)