### PR TITLE
Stop a workspace switch from cold-booting a fleet of agent CLIs

### DIFF
--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -132,6 +132,38 @@ to `ws2`, and shows the bar again. 685 workspace tests green, no new clippy warn
   now draw that header — harmless, but a future `text.contains("PROJECTS")` in one of them would fail.
 - One existing assertion had to move: `shift_w_toggles_the_workspaces_bar_and_parks_focus` checked
   `lines[1].starts_with("   PROJECTS")` on the hidden path; it's `"   DEFAULT"` now.
+### A Paused Rebase Renamed The Worktree Row To `detached @ …` — 2026-08-27
+
+**Asked:** "something in this conversation caused the worktree to show up in the UI but then it switvhed
+yp detached at f816b5f.  I wouldn't have expected the wortree name to become detached"
+
+**Did:** Diagnosed, then fixed in `95c0a18`. The cause was the `git rebase origin/main` in the entry above
+pausing on conflicts: a rebase parks HEAD on the commits it replays, so `git worktree list --porcelain`
+prints `detached` (no `branch` line) for the checkout for as long as it sits there. The 2s worktree sync
+(`reconcile_project_worktrees`, `registry.rs`) saw `known.branch != entry.branch`, wrote `detached @
+f816b5f` into the row and broadcast it, then wrote the branch back on the tick after `rebase --continue`
+finished. `git::list_worktrees` (`crates/nebula-daemon/src/git.rs`) now resolves a branch-less entry
+through the new `rebasing_branch(checkout)`: `git rev-parse --absolute-git-dir`, then
+`<git-dir>/{rebase-merge,rebase-apply}/head-name` (`refs/heads/<branch>` — the same file `git status`
+reads to say "rebasing branch X"). Only a checkout with no rebase in progress, or one rebasing from an
+already-detached HEAD (`head-name` reads `detached HEAD`), still gets `detached_label`. Test
+`a_paused_rebase_keeps_the_worktree_on_its_branch` walks mid-rebase → `--abort` → `checkout --detach`.
+147 daemon tests green.
+
+**Gotchas:**
+- **The row heals itself, so the bug is easy to write off as cosmetic — it isn't.** `nebula worktree
+  <name>` finds its target by `w.branch == branch` (`registry.rs:~1377`) and *creates* a worktree when
+  nothing matches, so an agent running it mid-rebase would have tried to add a second checkout for a
+  branch that already has one. Anything keyed on the branch string is blind for the whole pause.
+- The rebase state lives in the **per-worktree** git dir (`<repo>/.git/worktrees/<name>/rebase-merge/`),
+  not the shared `.git` — `git_common_dir` in `lib.rs` deliberately hops *to* the shared one for the
+  mtime probe and is the wrong helper here; `rev-parse --absolute-git-dir` from the checkout is right.
+- `git worktree list` may print canonical paths while `add_worktree` returns the tempdir spelling
+  (`/var/…` vs `/private/var/…` on macOS): the existing `remove_worktree_*` tests only assert
+  `e.path != wt`, which passes trivially either way. Canonicalize both sides when a test needs to *find*
+  the entry.
+- `git::current_branch` is a second, uncalled copy of this label logic with its own `detached@` format.
+  Left alone, but don't reach for it thinking it agrees with `list_worktrees`.
 
 ### Released v0.13.0 Off A Checkout Three Releases Stale — 2026-08-27
 

--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -341,6 +341,65 @@ on the session row *and* the project row above it. 450 nebula-tui + 143 daemon +
   never again: another session was editing this shared checkout mid-build. Rerun before debugging (see
   [Shared tree races] in the user memory).
 
+### A Workspace Switch Cold-Booted A Fleet Of Claude CLIs — 2026-08-26
+
+**Asked:** "in a worktree, debug a performance issue when a user switches between workspaces sometimes it
+seems like it's lagging or stuck loading up multiple claude sessions as the terminal panel doesn't show for
+like 5-10 seconds"
+
+**Did:** Three compounding causes, all confirmed against the live `~/.nebula-dev` daemon log and DB, fixed
+in `7246a47`.
+
+1. **Every switch attaches a *dead* session.** `session_idle_timeout` defaults to `5m`
+   (`nebula-daemon/src/config.rs:44`), and `reap_idle_sessions` kills everything in a workspace nobody is
+   attached to — the dev `daemon.log` is wall-to-wall `reaping idle session … idle_secs=300`. So
+   `switch_workspace_inner` → `restore_context` → `restore_session` → `attach` lands on a dead sref and
+   the daemon's `Attach` arm cold-spawns `zsh -l -i -c 'exec claude --resume <sid>'`. The replay it sends
+   back is **empty** (fresh ring), so the pane rendered a blank vt100 grid with no indication of anything
+   happening.
+2. **250ms later the prewarm booted every *other* session in the worktree, inline.**
+   `PrewarmWorktreeSessions` was handled synchronously on the connection's request loop
+   (`server.rs:426`, the old comment said "Deliberately inline"), and `prewarm_worktree_sessions` called
+   `ensure_session` for every dead non-archived row. `main` in the dev DB has **5 agents** → 5 concurrent
+   login-shell + claude boots, plus a 6th from `PrewarmAgent`, all starving the one the user was waiting
+   on — and stalling that client's `Input` frames for the whole burst.
+3. **`attach` had no debounce**, unlike prewarm. In the Workspaces column `move_selection` runs a full
+   `switch_workspace` per row (`event_loop.rs`), so walking past four workspaces cold-spawned four CLIs
+   and abandoned three, each then living 5 more minutes.
+
+Fixes: `Daemon::spawn_gate` (`registry.rs`) makes `ensure_session`'s check-and-install atomic, which is
+what lets the sweep leave the request loop — `run_worktree_prewarm` is now its own task, boots one session
+per `PREWARM_STAGGER` (1.5s), skips `is_alive` rows, and `prewarm_sweep` aborts a superseded sweep.
+TUI-side, `attach` defers the request by `ATTACH_DEBOUNCE` (180ms) via `pending_attach`, with
+`attached_sref` tracking what the daemon actually holds while `term.sref` runs ahead; `attach_now` /
+`preview_selected_now` skip the wait for explicit picks. `AttachedTerm::painted` drives a `starting…` tag
+plus a centered notice in `draw_terminal`. 631 tests green, fmt clean, no new clippy warnings.
+
+**Gotchas:**
+- **Measure the boot before blaming the code.** One fresh `claude` under `zsh -l -i` on this machine is
+  **0.67s to first byte, 1.47s to a painted screen** — and that's without `--resume` reloading a
+  transcript. Six of those at once is the whole 5-10s. A pty-fork bench spawning 4 at once got the shell
+  OOM-killed (exit 137) and 3 at once never finished in 120s; benchmark agent CLIs **one at a time**.
+- **`app.term` and the daemon's attachment are now two different things.** Tests that set
+  `app.term = Some(AttachedTerm::new(…))` directly leave `attached_sref` unset, so a `detach_if_attached`
+  keyed only on `attached_sref` silently stopped emitting `Detach` and broke 4 tests. Both
+  `detach_if_attached` and `release_attachment` deliberately fall back to `term.sref` — a `Detach` the
+  daemon holds no attachment for is a no-op there (`server.rs` `attached.remove()` returns `None`).
+- **Debouncing `attach` breaks every test that asserts an immediate `Attach` after a selection move.** 10
+  failed. Only 2 were genuinely the new contract (`session_arrows_preview_without_focusing`,
+  `switching_contexts_restores_the_remembered_session` — both now call `fire_pending_attach` to settle).
+  The other 8 were paths that *should* stay immediate: wrap `reconcile_selection` and `jump_to_target`
+  (both have early `return`s, so wrapping beats appending) and route clicks through
+  `preview_selected_now`.
+- **Input is dropped for a session the daemon hasn't spawned**, so a pending attach must land before the
+  first keystroke. `handle_terminal_event` fires it up front when `term_locked`; the two paths that take
+  the lock without attaching (`Action::Activate` on an already-focused pane, `Action::Zoom`) fire it too.
+- The 100-col draw-test truncation trap from [A Workspaces Column Left Of Projects] bites again: the
+  `starting…` test asserts pane body text, so it needs `show_workspaces = false` **and**
+  `TestBackend::new(140, 30)` or the string is clipped mid-assert.
+- The `switch_workspace_quietly` double-attach gotcha below is unaffected — the debounce happens to mask
+  that churn now, but the quiet variant is still what makes a cross-workspace jump correct.
+
 ### Released v0.11.0 Out Of A Shared Tree That Moved Mid-Release — 2026-08-26
 
 **Asked:** "commit push release"

--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -348,7 +348,8 @@ seems like it's lagging or stuck loading up multiple claude sessions as the term
 like 5-10 seconds"
 
 **Did:** Three compounding causes, all confirmed against the live `~/.nebula-dev` daemon log and DB, fixed
-in `7246a47`.
+in `327757f` (originally `7246a47`; the branch sat unmerged for a day and was rebased onto `origin/main`
+at v0.13.0 on 2026-08-27 — see the rebase notes at the end of this entry).
 
 1. **Every switch attaches a *dead* session.** `session_idle_timeout` defaults to `5m`
    (`nebula-daemon/src/config.rs:44`), and `reap_idle_sessions` kills everything in a workspace nobody is
@@ -373,7 +374,8 @@ per `PREWARM_STAGGER` (1.5s), skips `is_alive` rows, and `prewarm_sweep` aborts 
 TUI-side, `attach` defers the request by `ATTACH_DEBOUNCE` (180ms) via `pending_attach`, with
 `attached_sref` tracking what the daemon actually holds while `term.sref` runs ahead; `attach_now` /
 `preview_selected_now` skip the wait for explicit picks. `AttachedTerm::painted` drives a `starting…` tag
-plus a centered notice in `draw_terminal`. 631 tests green, fmt clean, no new clippy warnings.
+plus a centered notice in `draw_terminal`. 631 tests green when written; **657 green after the rebase**
+(exit 0, `--no-fail-fast`, all 7 binaries).
 
 **Gotchas:**
 - **Measure the boot before blaming the code.** One fresh `claude` under `zsh -l -i` on this machine is
@@ -399,6 +401,33 @@ plus a centered notice in `draw_terminal`. 631 tests green, fmt clean, no new cl
   `TestBackend::new(140, 30)` or the string is clipped mid-assert.
 - The `switch_workspace_quietly` double-attach gotcha below is unaffected — the debounce happens to mask
   that churn now, but the quiet variant is still what makes a cross-workspace jump correct.
+
+**Rebase onto v0.13.0 (2026-08-27), 20 commits later:**
+- Only two files conflicted (`registry.rs`, `event_loop.rs`); `server.rs`, `app.rs` and `ui.rs` merged
+  clean. Both `registry.rs` conflicts were additive-on-both-sides (main's `pending_moves` /
+  `cloud_attach_gated` / `cloud_mirrors` vs. this branch's `spawn_gate` / `prewarm_sweep`) — keep both.
+- **The one semantic conflict is `attach`.** Main added `mark_agent_seen` to the top of it (see
+  [Unwatched Finishes Count On The Project And Worktree Rows]) on the reasoning that every path landing
+  the pane on a session goes through `attach`. After this branch's split that funnel is `attach_inner`,
+  so the call moves there — keyed to the **pane swap, not the Attach**, because the user is reading the
+  screen during the debounce just the same. Putting it in `attach` alone would have skipped
+  `attach_now` / `preview_selected_now` and leaked unread counts on every explicit pick.
+- Two of main's newer tests failed, and they are not the same kind of failure:
+  `switching_back_to_a_workspace_restores_project_worktree_and_session` is *exactly* the path the
+  debounce exists for, so the test was updated to the new contract (pane restores now, Attach after
+  `fire_pending_attach`). `snapshot_reattaches_the_remembered_session` is not — a boot restores one
+  remembered session once, with no cursor sweep to wait out, so the Snapshot arm moved to
+  `preview_selected_now` and main's assertion stands unchanged. **A failing attach-timing test is a
+  question about which path it is, not a licence to relax the assertion.**
+- Struct drift in the branch's new test only: `Project` lost the four `divider_*` fields (migration 18)
+  and `Agent` gained `unseen` / `cloud_session_id` / `cloud_mirroring`. `cargo build` was clean and only
+  `cargo test --no-run` surfaced it — test-only literals need the test compile to be checked.
+- The workspaces *column* became a top tab bar on main, but `move_selection` there still does a full
+  `switch_workspace` per step, so the premise of cause 3 survived the rework and
+  `walking_the_workspaces_column_attaches_only_where_it_stops` passes untouched.
+- `cargo fmt --check` and clippy are **dirty on `origin/main` itself** (a `base64_encode` line, 7 clippy
+  warnings incl. `needless_return` at `event_loop.rs:5197`). None are in this diff — confirm with
+  `git diff origin/main --stat -- <file>` before assuming a warning is yours.
 
 ### Released v0.11.0 Out Of A Shared Tree That Moved Mid-Release — 2026-08-26
 

--- a/.claude/MEMORY.md
+++ b/.claude/MEMORY.md
@@ -132,6 +132,7 @@ to `ws2`, and shows the bar again. 685 workspace tests green, no new clippy warn
   now draw that header — harmless, but a future `text.contains("PROJECTS")` in one of them would fail.
 - One existing assertion had to move: `shift_w_toggles_the_workspaces_bar_and_parks_focus` checked
   `lines[1].starts_with("   PROJECTS")` on the hidden path; it's `"   DEFAULT"` now.
+
 ### A Paused Rebase Renamed The Worktree Row To `detached @ …` — 2026-08-27
 
 **Asked:** "something in this conversation caused the worktree to show up in the UI but then it switvhed
@@ -164,6 +165,14 @@ already-detached HEAD (`head-name` reads `detached HEAD`), still gets `detached_
   the entry.
 - `git::current_branch` is a second, uncalled copy of this label logic with its own `detached@` format.
   Left alone, but don't reach for it thinking it agrees with `list_worktrees`.
+- **A "load race" can be a build-layout race.** After this change `workspace_scope_is_per_connection`
+  (e2e_pty) failed 7 of 11 *idle* runs while the pre-change `git.rs` passed 13 of 13 — yet a probe
+  showed `rebasing_branch` was never called and the porcelain parse was identical. Adding file I/O to
+  `list_worktrees` for the probe made it pass 3/3: pure timing. It was the documented Ack-beats-upsert
+  race, and a code change that never runs in the test still shifts the odds. Fixed on the test side
+  (`6638952`): wait for the upsert *and* the Ack, as `cli_add_project` does; the TUI never relied on the
+  order (`event_loop.rs` "usually lands just before this Ack; if not, …"). A/B the old file in place
+  (`git show <sha>:path > path`, run, `git checkout -- path`) before believing either verdict.
 
 ### Released v0.13.0 Off A Checkout Three Releases Stale — 2026-08-27
 
@@ -639,7 +648,8 @@ HEAD = origin/main, working tree = v0.10.0 + the three features, still uncommitt
 - `git diff --quiet <commit>` only compares tracked files — it will say the tree matches even when
   untracked WIP is missing. `cmp` the untracked files separately.
 - `workspace_scope_is_per_connection` (e2e_pty) failed twice under a parallel clippy+test run and passed
-  alone: the Ack-beats-upsert load race the v0.10.0 entry describes, not the merge.
+  alone: the Ack-beats-upsert load race the v0.10.0 entry describes, not the merge (test fixed
+  2026-08-27, `6638952`).
 - The old Makefile's dev daemon lives at `/tmp/nebula-dev`; the new per-checkout slot is
   `/tmp/nebula-dev-<8 chars of shasum of $CURDIR>` (`2f3f877f` for the main checkout), so the new
   `dev-stop` cannot see a daemon the old recipe started. A `make dev` TUI that was already open keeps its
@@ -755,7 +765,8 @@ for the dot splitting violet (unread) from green (read) on the same `unseen` fla
   `cargo build --release` ran alongside, then passed alone and 2 of 2 idle full-suite runs. Its
   `expect("AddProject upserts the project")` only sees the broadcast upsert if it lands before the Ack —
   `server.rs` writes the Ack from the request loop and the upsert from the broadcast forwarder, so under
-  CPU contention the Ack can win. A load race, not a regression: rerun idle before debugging.
+  CPU contention the Ack can win. **Fixed 2026-08-27 (`6638952`):** the test now waits for the upsert as
+  well as the Ack, like `cli_add_project` always did — see [A Paused Rebase Renamed The Worktree Row].
 
 ### One Nebula Per Checkout: Auto-Port For `browser`, Per-Path Dev Slots — 2026-08-26
 

--- a/crates/nebula-daemon/src/git.rs
+++ b/crates/nebula-daemon/src/git.rs
@@ -77,21 +77,16 @@ pub struct WorktreeEntry {
 /// checkout.
 pub async fn list_worktrees(repo: &Path) -> Result<Vec<WorktreeEntry>> {
     let out = git(repo, &["worktree", "list", "--porcelain"]).await?;
-    let mut entries = Vec::new();
+    // (path, branch, HEAD) as git printed them; the label is decided below.
+    let mut raw: Vec<(PathBuf, Option<String>, Option<String>)> = Vec::new();
     let mut path: Option<PathBuf> = None;
     let mut branch: Option<String> = None;
     let mut head: Option<String> = None;
     for line in out.lines() {
         if let Some(p) = line.strip_prefix("worktree ") {
             if let Some(done_path) = path.take() {
-                entries.push(WorktreeEntry {
-                    path: done_path,
-                    branch: branch
-                        .take()
-                        .unwrap_or_else(|| detached_label(head.as_deref())),
-                });
+                raw.push((done_path, branch.take(), head.take()));
             }
-            head = None;
             path = Some(PathBuf::from(p));
         } else if let Some(sha) = line.strip_prefix("HEAD ") {
             head = Some(sha.to_string());
@@ -100,12 +95,49 @@ pub async fn list_worktrees(repo: &Path) -> Result<Vec<WorktreeEntry>> {
         }
     }
     if let Some(done_path) = path {
-        entries.push(WorktreeEntry {
-            path: done_path,
-            branch: branch.unwrap_or_else(|| detached_label(head.as_deref())),
-        });
+        raw.push((done_path, branch, head));
+    }
+    let mut entries = Vec::with_capacity(raw.len());
+    for (path, branch, head) in raw {
+        let branch = match branch {
+            Some(b) => b,
+            // No branch line: HEAD is detached. Usually that is a rebase
+            // parked on a conflict — HEAD sits on the commits being replayed
+            // for as long as the user takes to resolve it, and the branch
+            // comes back untouched when it finishes. The row is still that
+            // branch's row; renaming it "detached" for the duration makes a
+            // worktree look like it lost its identity, and breaks every
+            // lookup keyed on the branch name meanwhile.
+            None => match rebasing_branch(&path).await {
+                Some(b) => b,
+                None => detached_label(head.as_deref()),
+            },
+        };
+        entries.push(WorktreeEntry { path, branch });
     }
     Ok(entries)
+}
+
+/// The branch a paused rebase in `checkout` is replaying, if there is one —
+/// read from the same state file `git status` uses to say "rebasing branch
+/// X" while `git worktree list` calls the checkout detached. `None` for a
+/// checkout that is not rebasing, is rebasing a detached HEAD, or is gone.
+async fn rebasing_branch(checkout: &Path) -> Option<String> {
+    // Per-worktree git dir: the rebase state lives under
+    // `<repo>/.git/worktrees/<name>/` for a linked checkout, not in the
+    // shared `.git`.
+    let git_dir = git(checkout, &["rev-parse", "--absolute-git-dir"])
+        .await
+        .ok()?;
+    let git_dir = Path::new(git_dir.trim());
+    // `rebase-merge` is the default backend, `rebase-apply` the `--apply` one.
+    ["rebase-merge", "rebase-apply"]
+        .into_iter()
+        .find_map(|state| {
+            let name = std::fs::read_to_string(git_dir.join(state).join("head-name")).ok()?;
+            // Rebasing with HEAD already detached writes "detached HEAD" here.
+            Some(name.trim().strip_prefix("refs/heads/")?.to_string())
+        })
 }
 
 /// Display name for a checkout with no branch (detached HEAD).
@@ -238,6 +270,69 @@ mod tests {
         // A real git that says "not a repository" must keep saying so.
         let err = repo_toplevel(tmp.path()).await.unwrap_err();
         assert!(!is_missing(&err), "{err:#}");
+    }
+
+    /// A rebase parks HEAD on the commits it replays, so for as long as it
+    /// sits on a conflict `git worktree list` calls the checkout detached.
+    /// The row must keep its branch name through that: the branch is coming
+    /// back, and the worktree sync would otherwise rename the row twice per
+    /// rebase and hide it from every lookup keyed on the name meanwhile.
+    #[tokio::test]
+    async fn a_paused_rebase_keeps_the_worktree_on_its_branch() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        init_repo(&repo).await;
+        std::fs::write(repo.join("f"), "base\n").unwrap();
+        git(&repo, &["add", "f"]).await.unwrap();
+        git(&repo, &["commit", "-m", "base"]).await.unwrap();
+        let wt = add_worktree(&repo, "topic", None).await.unwrap();
+        // Both sides rewrite the same line, so the rebase has to stop.
+        std::fs::write(wt.join("f"), "topic\n").unwrap();
+        git(&wt, &["commit", "-am", "topic"]).await.unwrap();
+        std::fs::write(repo.join("f"), "main\n").unwrap();
+        git(&repo, &["commit", "-am", "main"]).await.unwrap();
+        assert!(git(&wt, &["rebase", "main"]).await.is_err());
+        // Precondition: git itself now reports no current branch there.
+        let current = git(&wt, &["branch", "--show-current"]).await.unwrap();
+        assert!(
+            current.trim().is_empty(),
+            "expected a detached HEAD mid-rebase"
+        );
+
+        // Paths come back canonical from git; the tempdir may be a symlink.
+        let wt_canon = wt.canonicalize().unwrap();
+        let branch_of = |entries: &[WorktreeEntry]| {
+            entries
+                .iter()
+                .find(|e| e.path.canonicalize().ok() == Some(wt_canon.clone()))
+                .map(|e| e.branch.clone())
+                .expect("the worktree is listed")
+        };
+
+        let entries = list_worktrees(&repo).await.unwrap();
+        assert_eq!(
+            branch_of(&entries),
+            "topic",
+            "mid-rebase: still the branch's row"
+        );
+
+        git(&wt, &["rebase", "--abort"]).await.unwrap();
+        let entries = list_worktrees(&repo).await.unwrap();
+        assert_eq!(
+            branch_of(&entries),
+            "topic",
+            "after: the ordinary branch line"
+        );
+
+        // A checkout that genuinely detached still says so.
+        git(&wt, &["checkout", "--detach"]).await.unwrap();
+        let entries = list_worktrees(&repo).await.unwrap();
+        assert!(
+            branch_of(&entries).starts_with("detached @ "),
+            "a real detached HEAD is still labelled as one, got {:?}",
+            branch_of(&entries)
+        );
     }
 
     #[tokio::test]

--- a/crates/nebula-daemon/src/registry.rs
+++ b/crates/nebula-daemon/src/registry.rs
@@ -28,6 +28,12 @@ const PREWARM_MAX_AGE: Duration = Duration::from_secs(15 * 60);
 /// `PREWARM_MAX_AGE - PREWARM_RECYCLE_AGE`, so a slot they still care about
 /// is always refreshed before the reaper can empty it.
 const PREWARM_RECYCLE_AGE: Duration = Duration::from_secs(10 * 60);
+/// Gap between the boots of a worktree prewarm sweep. A worktree with five
+/// agents must not fork five agent CLIs at once: they would all contend for
+/// the CPU with the one session the user is actually waiting to see, which
+/// is the whole reason the sweep exists. Nothing is watching these, so
+/// warming them slowly costs the user nothing.
+const PREWARM_STAGGER: Duration = Duration::from_millis(1500);
 /// Hook events buffered on a warm session before its row exists (oldest
 /// dropped beyond this).
 const PREWARM_HOOK_BUFFER_CAP: usize = 64;
@@ -142,6 +148,15 @@ pub struct Daemon {
     /// Cloud rows currently being mirrored (periodic re-teleport). Keyed by
     /// agent so a second follow request replaces rather than doubles up.
     cloud_mirrors: Mutex<HashMap<AgentId, Arc<tokio_util::sync::CancellationToken>>>,
+    /// Serializes the check-and-spawn inside [`Daemon::ensure_session`].
+    /// Attach (the request loop) and the worktree prewarm sweep (its own
+    /// task) can both reach for the same dead session; without this they
+    /// would both miss the registry and fork two CLIs, orphaning one.
+    spawn_gate: Mutex<()>,
+    /// The worktree prewarm sweep currently running, so a newer one can
+    /// cancel it. Stepping through the Workspaces column fires a sweep per
+    /// row, and only the row the cursor rests on is worth warming.
+    prewarm_sweep: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl Daemon {
@@ -163,6 +178,8 @@ impl Daemon {
             pending_moves: Mutex::new(HashMap::new()),
             cloud_attach_gated: AtomicBool::new(false),
             cloud_mirrors: Mutex::new(HashMap::new()),
+            spawn_gate: Mutex::new(()),
+            prewarm_sweep: Mutex::new(None),
         })
     }
 
@@ -2185,6 +2202,13 @@ impl Daemon {
         if let Some(s) = self.session(sref) {
             return Ok(s);
         }
+        // Hold the gate across the whole check-and-install: an Attach and the
+        // prewarm sweep racing the same dead session must produce one CLI,
+        // not two. Re-check under it — the winner installed while we waited.
+        let _gate = self.spawn_gate.lock().unwrap();
+        if let Some(s) = self.session(sref) {
+            return Ok(s);
+        }
         match sref {
             SessionRef::Agent(id) => {
                 let agent = self.store.get_agent(id)?.context("agent not found")?;
@@ -2234,10 +2258,32 @@ impl Daemon {
         if !crate::config::Config::load().prewarm_sessions {
             return;
         }
+        let daemon = self.clone();
+        let worktree_id = worktree_id.clone();
+        let handle = tokio::spawn(async move {
+            daemon.run_worktree_prewarm(&worktree_id, cols, rows).await;
+        });
+        // Supersede whatever sweep was still warming the worktree the user
+        // has now left; its remaining boots are wasted work.
+        if let Some(old) = self.prewarm_sweep.lock().unwrap().replace(handle) {
+            old.abort();
+        }
+    }
+
+    /// The sweep itself: boot the worktree's dead sessions one at a time,
+    /// [`PREWARM_STAGGER`] apart. Deliberately off the connection's request
+    /// loop — it used to run inline, which stalled that client's Input and
+    /// Attach frames for as long as the whole burst of forks took.
+    async fn run_worktree_prewarm(
+        self: &Arc<Self>,
+        worktree_id: &WorktreeId,
+        cols: u16,
+        rows: u16,
+    ) {
         let Ok((_, _, agents, terminals)) = self.store.load_tree() else {
             return;
         };
-        let srefs = agents
+        let srefs: Vec<SessionRef> = agents
             .iter()
             .filter(|a| &a.worktree_id == worktree_id && !a.archived)
             .map(|a| SessionRef::Agent(a.id.clone()))
@@ -2246,14 +2292,32 @@ impl Daemon {
                     .iter()
                     .filter(|t| &t.worktree_id == worktree_id)
                     .map(|t| SessionRef::Terminal(t.id.clone())),
-            );
+            )
+            .collect();
         for sref in srefs {
             // The prewarm doubles as a "user is looking here" signal for
             // the idle reaper, for alive sessions as much as fresh spawns.
             self.touch_session(&sref);
-            if let Err(e) = self.ensure_session(&sref, cols, rows) {
-                tracing::debug!(session = ?sref, error = %e, "session prewarm failed");
+            // Already warm — most importantly the one the user just
+            // attached to, which Attach spawned a moment ago.
+            if self.is_alive(&sref) {
+                continue;
             }
+            let daemon = self.clone();
+            let target = sref.clone();
+            // fork/exec blocks; keep it off the async worker threads.
+            let spawned = tokio::task::spawn_blocking(move || {
+                daemon.ensure_session(&target, cols, rows).map(|_| ())
+            })
+            .await;
+            match spawned {
+                Ok(Err(e)) => {
+                    tracing::debug!(session = ?sref, error = %e, "session prewarm failed")
+                }
+                Err(e) => tracing::debug!(session = ?sref, error = %e, "session prewarm panicked"),
+                Ok(Ok(())) => {}
+            }
+            tokio::time::sleep(PREWARM_STAGGER).await;
         }
     }
 

--- a/crates/nebula-daemon/src/server.rs
+++ b/crates/nebula-daemon/src/server.rs
@@ -403,11 +403,11 @@ async fn handle_client(daemon: Arc<Daemon>, stream: UnixStream) -> Result<()> {
                     cols,
                     rows,
                 } => {
-                    // Deliberately inline: an Attach for one of these
-                    // sessions is then ordered after it instead of racing it
-                    // (two concurrent ensure_session calls for the same sref
-                    // would double-spawn). Spawns are forkpty-fast; the
-                    // children boot in the background.
+                    // Returns at once: the sweep boots the worktree's dead
+                    // sessions on its own task, staggered, skipping the one
+                    // the Attach above already spawned. Racing that Attach is
+                    // safe — ensure_session's spawn gate makes the
+                    // check-and-spawn atomic, so neither can double-fork.
                     daemon.prewarm_worktree_sessions(&worktree, cols, rows);
                 }
                 ClientRequest::RenameAgent { req_id, id, name } => {

--- a/crates/nebula-tui/src/app.rs
+++ b/crates/nebula-tui/src/app.rs
@@ -1681,6 +1681,12 @@ pub struct AttachedTerm {
     /// The child's kitty keyboard flags (daemon-tracked); picks the key
     /// encoding dialect. 0 = legacy.
     pub kitty_flags: u8,
+    /// Whether any PTY bytes have reached this parser yet. False means the
+    /// grid is blank because the session is still booting — attaching to a
+    /// reaped session replays an empty ring, and an agent CLI takes seconds
+    /// to paint its first frame. The pane says so instead of showing an
+    /// unexplained void.
+    pub painted: bool,
 }
 
 impl AttachedTerm {
@@ -1693,6 +1699,7 @@ impl AttachedTerm {
             rows,
             scroll: 0,
             kitty_flags: 0,
+            painted: false,
         }
     }
 
@@ -1701,6 +1708,7 @@ impl AttachedTerm {
         self.parser = vt100::Parser::new(self.rows, self.cols, 10_000);
         self.exited = false;
         self.scroll = 0;
+        self.painted = false;
     }
 
     pub fn set_scroll(&mut self, scroll: usize) {
@@ -1907,6 +1915,16 @@ pub struct App {
     /// deadline — armed on every worktree context switch, so walking the
     /// list doesn't boot every CLI it passes.
     pub pending_prewarm: Option<(WorktreeId, std::time::Instant)>,
+    /// Debounced attach: the session the pane is showing but the daemon has
+    /// not been told about yet. Stepping a selection is not a decision to
+    /// boot a CLI — and in the Workspaces column every step is a full
+    /// workspace switch, so without this, walking past four workspaces
+    /// cold-spawns four agents and abandons three of them.
+    pub pending_attach: Option<(SessionRef, std::time::Instant)>,
+    /// What this connection is attached to daemon-side. Lags `term.sref`
+    /// while an attach waits out its debounce, so the Detach that precedes
+    /// the next Attach names the session the daemon actually holds.
+    pub attached_sref: Option<SessionRef>,
     /// Standing keep-warm: when to next re-assert the selected worktree's
     /// warm default-spec Claude session, so one is always ready to adopt.
     /// Re-armed after every send; disarmed when nothing is selected.
@@ -2111,6 +2129,8 @@ impl App {
             last_session_for_worktree: HashMap::new(),
             last_project_for_workspace: HashMap::new(),
             pending_prewarm: None,
+            pending_attach: None,
+            attached_sref: None,
             next_keepwarm: None,
             term_selection: None,
             last_term_click: None,
@@ -2637,6 +2657,12 @@ impl App {
     /// event loop can wake up and fire it. None when nothing is armed.
     pub fn prewarm_delay(&self) -> Option<std::time::Duration> {
         let (_, at) = self.pending_prewarm.as_ref()?;
+        Some(at.saturating_duration_since(std::time::Instant::now()))
+    }
+
+    /// How long until the debounced attach should be sent, if one is armed.
+    pub fn attach_delay(&self) -> Option<std::time::Duration> {
+        let (_, at) = self.pending_attach.as_ref()?;
         Some(at.saturating_duration_since(std::time::Instant::now()))
     }
 

--- a/crates/nebula-tui/src/event_loop.rs
+++ b/crates/nebula-tui/src/event_loop.rs
@@ -51,6 +51,11 @@ const AGO_REFRESH: Duration = Duration::from_secs(30);
 /// list doesn't boot every CLI passed, short enough that the sessions are
 /// booting well before the user picks one.
 const PREWARM_DEBOUNCE: Duration = Duration::from_millis(250);
+/// How long a selection-driven attach waits for the cursor to settle. Long
+/// enough that walking a list (or the Workspaces column, where every step is
+/// a whole workspace switch) attaches only where the cursor stops; short
+/// enough to feel immediate when it does stop.
+const ATTACH_DEBOUNCE: Duration = Duration::from_millis(180);
 
 /// How often the standing keep-warm request for the selected worktree's
 /// default-spec Claude session is re-sent. Must stay comfortably under the
@@ -332,6 +337,13 @@ async fn main_loop(
                     }
                 }
                 app.dirty = true;
+            }
+            // The selection rested past the debounce: tell the daemon what
+            // the pane has been showing since the cursor landed here.
+            _ = tokio::time::sleep(app.attach_delay().unwrap_or_default()),
+                if app.pending_attach.is_some() =>
+            {
+                fire_pending_attach(&mut app, &mut out);
             }
             // The worktree selection rested past the debounce: ask the
             // daemon to boot its dead sessions in the background so
@@ -1052,6 +1064,12 @@ fn close_vim(app: &mut App) {
 }
 
 fn handle_terminal_event(app: &mut App, event: Event, out: &mut Vec<ClientRequest>) {
+    // With the pane holding input, whatever this event turns into is headed
+    // for the PTY — and the daemon drops Input for a session it hasn't
+    // spawned. A still-debounced attach has to land before the keystroke.
+    if app.term_locked {
+        fire_pending_attach(app, out);
+    }
     match event {
         Event::Key(key) if key.kind != KeyEventKind::Release => {
             app.flash = None;
@@ -1283,7 +1301,7 @@ fn handle_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>) {
             Focus::Workspaces => app.focus = Focus::Projects,
             Focus::Projects => app.focus = Focus::Worktrees,
             Focus::Worktrees => app.focus = Focus::Sessions,
-            Focus::Sessions | Focus::Terminal => enter_terminal_pane(app),
+            Focus::Sessions | Focus::Terminal => enter_terminal_pane(app, out),
         },
         // ⇧Tab / ^⇧H walk back and stop dead at the first column — the
         // Workspaces bar while it's shown, Projects when it's hidden.
@@ -1400,7 +1418,7 @@ fn handle_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>) {
             },
             Focus::Sessions => attach_selected(app, out),
             // Lock input into an already-focused live pane.
-            Focus::Terminal => enter_terminal_pane(app),
+            Focus::Terminal => enter_terminal_pane(app, out),
         },
         // First run (or an empty workspace): with no visible projects every
         // panel is empty and the splash is up — New creates a project no
@@ -1550,6 +1568,7 @@ fn handle_key(app: &mut App, key: KeyEvent, out: &mut Vec<ClientRequest>) {
                 app.collapsed = true;
                 app.focus = Focus::Terminal;
                 app.term_locked = true;
+                fire_pending_attach(app, out);
             } else {
                 app.flash = Some("attach a session first".into());
             }
@@ -3955,7 +3974,7 @@ fn run_pending_action(app: &mut App, action: PendingAction, out: &mut Vec<Client
 fn run_menu_action(app: &mut App, action: MenuAction, out: &mut Vec<ClientRequest>) {
     match action {
         MenuAction::Attach(sref) => {
-            attach(app, sref, out);
+            attach_now(app, sref, out);
             app.focus = Focus::Terminal;
             app.term_locked = true;
         }
@@ -4135,16 +4154,24 @@ fn run_menu_action(app: &mut App, action: MenuAction, out: &mut Vec<ClientReques
 }
 
 fn detach_if_attached(app: &mut App, sref: &SessionRef, out: &mut Vec<ClientRequest>) {
-    if let Some(term) = &app.term {
-        if &term.sref == sref {
-            out.push(ClientRequest::Detach {
-                session: sref.clone(),
-            });
-            app.term = None;
-            app.term_locked = false;
-            if app.focus == Focus::Terminal {
-                app.focus = Focus::Sessions;
-            }
+    // The daemon may hold this session even when the pane has already moved
+    // on to another one whose attach is still debounced — release it either
+    // way, or the connection stays attached to a row that no longer exists.
+    let showing = app.term.as_ref().is_some_and(|t| &t.sref == sref);
+    if app.attached_sref.as_ref() == Some(sref) || showing {
+        out.push(ClientRequest::Detach {
+            session: sref.clone(),
+        });
+        if app.attached_sref.as_ref() == Some(sref) {
+            app.attached_sref = None;
+        }
+    }
+    if showing {
+        app.pending_attach = None;
+        app.term = None;
+        app.term_locked = false;
+        if app.focus == Focus::Terminal {
+            app.focus = Focus::Sessions;
         }
     }
 }
@@ -4272,11 +4299,8 @@ fn restore_session(app: &mut App, out: &mut Vec<ClientRequest>) {
             attach(app, sref, out);
         }
         None => {
-            if let Some(term) = &app.term {
-                let session = term.sref.clone();
-                out.push(ClientRequest::Detach { session });
-                app.term = None;
-                app.term_locked = false;
+            if app.term.is_some() {
+                detach_pane(app, out);
             }
         }
     }
@@ -4428,7 +4452,19 @@ fn target_workspace(app: &App, target: &PaletteTarget) -> Option<WorkspaceId> {
 /// are re-validated against the
 /// tree — a pick can race a removal, in which case it flashes instead of
 /// jumping.
+/// Land the palette/finder on `target`, attaching without the debounce —
+/// the user typed a query and picked a row, which is as explicit as it gets.
 fn jump_to_target(
+    app: &mut App,
+    target: PaletteTarget,
+    attach: bool,
+    out: &mut Vec<ClientRequest>,
+) {
+    jump_to_target_inner(app, target, attach, out);
+    fire_pending_attach(app, out);
+}
+
+fn jump_to_target_inner(
     app: &mut App,
     target: PaletteTarget,
     attach: bool,
@@ -4663,6 +4699,16 @@ fn move_selection(app: &mut App, delta: i64, out: &mut Vec<ClientRequest>) {
 /// previews each session so it can be read; Enter (or a double-click) is
 /// what commits: focus + lock. Archived rows don't preview.
 fn preview_selected(app: &mut App, out: &mut Vec<ClientRequest>) {
+    preview_inner(app, ATTACH_DEBOUNCE, out);
+}
+
+/// Preview with no debounce — a click points at exactly one row, so there is
+/// no sweep to wait out.
+fn preview_selected_now(app: &mut App, out: &mut Vec<ClientRequest>) {
+    preview_inner(app, Duration::ZERO, out);
+}
+
+fn preview_inner(app: &mut App, delay: Duration, out: &mut Vec<ClientRequest>) {
     let Some(row) = app.selected_session_row() else {
         return;
     };
@@ -4674,7 +4720,7 @@ fn preview_selected(app: &mut App, out: &mut Vec<ClientRequest>) {
     let Some(sref) = row.sref() else {
         return;
     };
-    attach(app, sref, out);
+    attach_inner(app, sref, delay, out);
 }
 
 /// Enter on the Sessions panel: attach the session under the cursor, or —
@@ -4690,7 +4736,7 @@ fn attach_selected(app: &mut App, out: &mut Vec<ClientRequest>) {
         }
         return;
     };
-    attach(app, sref, out);
+    attach_now(app, sref, out);
     app.focus = Focus::Terminal;
     app.term_locked = true;
 }
@@ -4698,11 +4744,14 @@ fn attach_selected(app: &mut App, out: &mut Vec<ClientRequest>) {
 /// Cross into the terminal pane and take the input lock, so what the user
 /// types after the walk reaches the agent instead of the panels. An empty
 /// or dead pane is focused but never locked: there is nothing to type into,
-/// and a lock would only send them hunting for an escape hatch.
-fn enter_terminal_pane(app: &mut App) {
+/// and a lock would only send them hunting for an escape hatch. Taking the
+/// lock is a commitment to this session, so a debounced attach stops
+/// waiting: keystrokes are about to need it.
+fn enter_terminal_pane(app: &mut App, out: &mut Vec<ClientRequest>) {
     app.focus = Focus::Terminal;
     if app.term.as_ref().is_some_and(|t| !t.exited) {
         app.term_locked = true;
+        fire_pending_attach(app, out);
     }
 }
 
@@ -4759,30 +4808,101 @@ fn mark_agent_seen(app: &mut App, id: &AgentId, out: &mut Vec<ClientRequest>) {
     out.push(ClientRequest::MarkAgentSeen { id: id.clone() });
 }
 
+/// Show `sref` in the pane, telling the daemon once the selection settles.
+/// The pane swaps immediately — the header must never name a session other
+/// than the selected one — but the Attach itself waits out
+/// [`ATTACH_DEBOUNCE`], because attaching a reaped session makes the daemon
+/// fork an agent CLI, and a cursor merely passing through a row has not
+/// asked for that.
 fn attach(app: &mut App, sref: SessionRef, out: &mut Vec<ClientRequest>) {
+    attach_inner(app, sref, ATTACH_DEBOUNCE, out);
+}
+
+/// Attach with no debounce: the user named this row outright (Enter, a
+/// click, the menu, a session they just created), so there is nothing to
+/// wait to see whether they meant it.
+fn attach_now(app: &mut App, sref: SessionRef, out: &mut Vec<ClientRequest>) {
+    attach_inner(app, sref, Duration::ZERO, out);
+}
+
+fn attach_inner(app: &mut App, sref: SessionRef, delay: Duration, out: &mut Vec<ClientRequest>) {
     // Whatever lands in the pane has been looked at — walking the cursor
     // onto a row previews it here, so this is where the counts come down.
+    // Keyed to the pane swap, not to the Attach: the user is reading the
+    // screen during the debounce just the same.
     if let SessionRef::Agent(id) = &sref {
         mark_agent_seen(app, id, out);
     }
-    if let Some(existing) = &app.term {
-        if existing.sref == sref && !existing.exited {
-            return; // already attached
-        }
-        out.push(ClientRequest::Detach {
-            session: existing.sref.clone(),
-        });
+    let showing = app
+        .term
+        .as_ref()
+        .is_some_and(|t| t.sref == sref && !t.exited);
+    if !showing {
+        let (cols, rows) = pane_size(app);
+        // Fresh screen, so any persisted selection would point at stale cells.
+        app.term_selection = None;
+        app.term = Some(AttachedTerm::new(sref.clone(), cols, rows));
+        app.dirty = true;
+    }
+    if delay.is_zero() {
+        app.pending_attach = None;
+        send_attach(app, sref, out);
+    } else if app.attached_sref.as_ref() == Some(&sref) {
+        // The daemon already holds it; nothing to send, nothing to wait for.
+        app.pending_attach = None;
+    } else {
+        app.pending_attach = Some((sref, std::time::Instant::now() + delay));
+    }
+}
+
+/// Move the daemon-side attachment to `sref`, releasing whatever it held.
+/// Idempotent, so every caller can just ask for the session it wants.
+fn send_attach(app: &mut App, sref: SessionRef, out: &mut Vec<ClientRequest>) {
+    if app.attached_sref.as_ref() == Some(&sref) {
+        return;
+    }
+    if let Some(old) = app.attached_sref.take() {
+        out.push(ClientRequest::Detach { session: old });
     }
     let (cols, rows) = pane_size(app);
-    // Fresh screen, so any persisted selection would point at stale cells.
-    app.term_selection = None;
-    app.term = Some(AttachedTerm::new(sref.clone(), cols, rows));
+    app.attached_sref = Some(sref.clone());
     out.push(ClientRequest::Attach {
         session: sref,
         from_seq: None,
         cols,
         rows,
     });
+}
+
+/// Send the armed attach now — the selection settled, or something needs
+/// the session live this instant (a keystroke about to be forwarded).
+fn fire_pending_attach(app: &mut App, out: &mut Vec<ClientRequest>) {
+    let Some((sref, _)) = app.pending_attach.take() else {
+        return;
+    };
+    send_attach(app, sref, out);
+}
+
+/// Release the daemon-side attachment: whatever the daemon holds, or — when
+/// an attach is still debounced — the session the pane is showing, so a
+/// caller that only knows about the pane still lets go. A Detach the daemon
+/// has no attachment for costs it a hash lookup and nothing else.
+fn release_attachment(app: &mut App, out: &mut Vec<ClientRequest>) {
+    app.pending_attach = None;
+    let session = app
+        .attached_sref
+        .take()
+        .or_else(|| app.term.as_ref().map(|t| t.sref.clone()));
+    if let Some(session) = session {
+        out.push(ClientRequest::Detach { session });
+    }
+}
+
+/// Blank the pane and release the daemon-side attachment.
+fn detach_pane(app: &mut App, out: &mut Vec<ClientRequest>) {
+    release_attachment(app, out);
+    app.term = None;
+    app.term_locked = false;
 }
 
 /// Terminal-pane grid for spawn/attach requests; the fallback keeps
@@ -5811,7 +5931,7 @@ fn handle_mouse(app: &mut App, mouse: MouseEvent, out: &mut Vec<ClientRequest>) 
                                 // click commits.
                                 app.last_session_click = Some((now, key));
                                 app.focus = Focus::Sessions;
-                                preview_selected(app, out);
+                                preview_selected_now(app, out);
                             }
                         }
                         None => {}
@@ -6190,8 +6310,11 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
             schedule_prewarm(app);
             // The cursor came back on the session the user left on; bring
             // its terminal back with it, exactly as landing on the row would.
+            // No debounce: a boot restores one remembered session once, so
+            // there is no cursor sweep to wait out — only the user waiting
+            // to see the screen they left.
             if session_restored {
-                preview_selected(app, out);
+                preview_selected_now(app, out);
             }
             app.dirty = true;
         }
@@ -6201,6 +6324,7 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
                     // Full replay: the screen is rebuilt from scratch.
                     app.term_selection = None;
                     term.reset();
+                    term.painted = !data.is_empty();
                     term.parser.process(&data);
                     app.dirty = true;
                 }
@@ -6209,6 +6333,7 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
         ServerEvent::Output { session, data, .. } => {
             if let Some(term) = &mut app.term {
                 if term.sref == session {
+                    term.painted |= !data.is_empty();
                     term.parser.process(&data);
                     app.dirty = true;
                 }
@@ -6282,7 +6407,7 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
                         // Its upsert usually lands just before this Ack; land
                         // the selection now, or on the upsert otherwise.
                         land_pending_selection(app, out);
-                        attach(app, sref, out);
+                        attach_now(app, sref, out);
                         app.focus = Focus::Terminal;
                         app.term_locked = true;
                     }
@@ -6597,7 +6722,20 @@ fn selection_snapshot(app: &App) -> SelectionSnapshot {
 /// there (restore_context / restore_session / preview). The invariant: the
 /// terminal pane always shows the highlighted session, never a stale or
 /// blank one.
+/// Re-seat the selection after the tree changed under it, then attach at
+/// once. A delete, an archive or a move is an explicit act and the row the
+/// cursor gets pushed onto is where it stays — there is no sweep to wait
+/// out, unlike the key-walking that `attach`'s debounce exists for.
 fn reconcile_selection(app: &mut App, before: SelectionSnapshot, out: &mut Vec<ClientRequest>) {
+    reconcile_selection_inner(app, before, out);
+    fire_pending_attach(app, out);
+}
+
+fn reconcile_selection_inner(
+    app: &mut App,
+    before: SelectionSnapshot,
+    out: &mut Vec<ClientRequest>,
+) {
     clamp_selections(app);
     if let Some(pid) = &before.project {
         if !app.tree.projects.iter().any(|p| &p.id == pid) {
@@ -10947,9 +11085,22 @@ diff --git a/src/b.rs b/src/b.rs
             Some(a2.clone()),
             "the walked-to session shows in the pane"
         );
+        // The pane swaps at once, but the Attach waits for the cursor to
+        // settle — walking a list must not boot a CLI per row passed.
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, ClientRequest::Attach { .. })),
+            "the walk itself attaches nothing: {out:?}"
+        );
+        assert_eq!(
+            app.pending_attach.as_ref().map(|(s, _)| s.clone()),
+            Some(a2.clone()),
+            "the attach is armed for the walked-to session"
+        );
+        fire_pending_attach(&mut app, &mut out);
         assert!(
             matches!(out.last(), Some(ClientRequest::Attach { session, .. }) if *session == a2),
-            "preview attaches so scrollback streams in"
+            "settling attaches so scrollback streams in: {out:?}"
         );
 
         // Walking onto an archived row keeps the previous preview.
@@ -12275,6 +12426,9 @@ diff --git a/src/b.rs b/src/b.rs
             KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE),
             &mut out,
         );
+        // The pane comes back at once; the Attach waits out the debounce, so
+        // sweeping through worktrees doesn't cold-boot each one in passing.
+        fire_pending_attach(&mut app, &mut out);
         assert!(
             matches!(out.last(), Some(ClientRequest::Attach { session, .. }) if *session == sref),
             "returning to w1 re-attaches its session: {out:?}"
@@ -16209,10 +16363,24 @@ diff --git a/src/b.rs b/src/b.rs
             Some(a2.clone()),
             "and that worktree's remembered session"
         );
+        assert_eq!(
+            app.term.as_ref().map(|t| t.sref.clone()),
+            Some(a2.clone()),
+            "the remembered session comes back in the pane too"
+        );
+        // The Attach itself waits out ATTACH_DEBOUNCE: walking the
+        // Workspaces column runs a full switch per row, and a workspace
+        // merely passed through must not cold-boot its agent CLI.
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, ClientRequest::Attach { .. })),
+            "the attach is debounced, not sent on the switch itself, got {out:?}"
+        );
+        fire_pending_attach(&mut app, &mut out);
         assert!(
             out.iter()
                 .any(|r| matches!(r, ClientRequest::Attach { session, .. } if *session == a2)),
-            "the remembered session comes back in the pane too, got {out:?}"
+            "and lands once the cursor settles, got {out:?}"
         );
     }
 
@@ -16291,6 +16459,186 @@ diff --git a/src/b.rs b/src/b.rs
             },
         );
     }
+    /// Stepping through the Workspaces column runs a full `switch_workspace`
+    /// per row, and each one restores that workspace's remembered session.
+    /// Without the attach debounce every row merely passed through
+    /// cold-boots an agent CLI nobody asked to see, and the boot the user IS
+    /// waiting on queues behind them — the workspace-switch lag.
+    #[test]
+    fn walking_the_workspaces_column_attaches_only_where_it_stops() {
+        use nebula_core::{
+            Agent, AgentStatus, Entity, Project, ProjectId, Workspace, WorkspaceId, Worktree,
+        };
+        let mut app = App::new();
+        seed_tree(&mut app);
+        seed_default_workspace(&mut app);
+        seed_other_workspace(&mut app); // ws2 → p9 → w9
+        seed_background_run(&mut app); // a9 lives in w9
+
+        // A third workspace, so the walk genuinely passes *through* ws2.
+        hse(
+            &mut app,
+            ServerEvent::EntityUpserted {
+                entity: Entity::Workspace(Workspace {
+                    id: WorkspaceId("ws3".into()),
+                    name: "third".into(),
+                }),
+            },
+        );
+        hse(
+            &mut app,
+            ServerEvent::EntityUpserted {
+                entity: Entity::Project(Project {
+                    workspace_id: WorkspaceId("ws3".into()),
+                    id: ProjectId("p7".into()),
+                    name: "third-proj".into(),
+                    repo_path: "/tmp/third".into(),
+                    sort_order: 7,
+                }),
+            },
+        );
+        hse(
+            &mut app,
+            ServerEvent::EntityUpserted {
+                entity: Entity::Worktree(Worktree {
+                    id: WorktreeId("w7".into()),
+                    project_id: ProjectId("p7".into()),
+                    path: "/tmp/third".into(),
+                    branch: "main".into(),
+                    is_main: true,
+                    pinned: false,
+                    sort_order: 0,
+                }),
+            },
+        );
+        hse(
+            &mut app,
+            ServerEvent::EntityUpserted {
+                entity: Entity::Agent(Agent {
+                    id: AgentId("a7".into()),
+                    worktree_id: WorktreeId("w7".into()),
+                    name: "third-agent".into(),
+                    status: AgentStatus::Fresh,
+                    archived: false,
+                    archived_at: 0,
+                    pinned: false,
+                    unseen: false,
+                    kind: AgentKind::Claude,
+                    model: None,
+                    effort: None,
+                    session_id: None,
+                    cloud_session_id: None,
+                    sort_order: 0,
+                    status_changed_at: 0,
+                    alive: true,
+                    cloud_mirroring: false,
+                }),
+            },
+        );
+        // Both destinations remember a session, so a restoring switch has
+        // something to attach in each.
+        app.last_session_for_worktree.insert(
+            WorktreeId("w9".into()),
+            SessionRef::Agent(AgentId("a9".into())),
+        );
+        app.last_session_for_worktree.insert(
+            WorktreeId("w7".into()),
+            SessionRef::Agent(AgentId("a7".into())),
+        );
+
+        app.focus = Focus::Workspaces;
+        let mut out = Vec::new();
+        move_selection(&mut app, 1, &mut out); // onto ws2…
+        move_selection(&mut app, 1, &mut out); // …and straight through to ws3
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, ClientRequest::Attach { .. })),
+            "nothing attaches while the cursor is still moving: {out:?}"
+        );
+        assert!(
+            !out.iter()
+                .any(|r| matches!(r, ClientRequest::Attach { session, .. }
+                if *session == SessionRef::Agent(AgentId("a9".into())))),
+            "the workspace passed through never boots its agent: {out:?}"
+        );
+
+        fire_pending_attach(&mut app, &mut out);
+        let attaches: Vec<_> = out
+            .iter()
+            .filter(|r| matches!(r, ClientRequest::Attach { .. }))
+            .collect();
+        assert_eq!(
+            attaches.len(),
+            1,
+            "exactly one attach, for the row it stopped on: {out:?}"
+        );
+        assert!(
+            matches!(out.last(), Some(ClientRequest::Attach { session, .. })
+                if *session == SessionRef::Agent(AgentId("a7".into()))),
+            "and it's the workspace the walk ended on: {out:?}"
+        );
+    }
+
+    /// An attach whose session the daemon had reaped replays an empty ring,
+    /// so the grid is blank for as long as the CLI takes to boot. The pane
+    /// has to say that rather than look hung.
+    #[test]
+    fn a_booting_session_says_so_instead_of_showing_a_blank_pane() {
+        let mut app = App::new();
+        seed_tree(&mut app);
+        let sref = SessionRef::Agent(AgentId("a1".into()));
+        let mut out = Vec::new();
+        attach_now(&mut app, sref.clone(), &mut out);
+        // Wide, and without the Workspaces column: the terminal pane has to
+        // be roomy enough that its text isn't truncated mid-assert.
+        app.show_workspaces = false;
+        let mut terminal = Terminal::new(TestBackend::new(140, 30)).unwrap();
+
+        terminal.draw(|f| ui::draw(f, &mut app)).unwrap();
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains("starting"),
+            "a session with no output yet reads as starting:\n{text}"
+        );
+
+        // The empty replay on attach is not output — it must not clear the
+        // notice, or the pane goes blank again with nothing to explain it.
+        hse(
+            &mut app,
+            ServerEvent::Scrollback {
+                session: sref.clone(),
+                base_seq: 0,
+                data: Vec::new(),
+            },
+        );
+        terminal.draw(|f| ui::draw(f, &mut app)).unwrap();
+        assert!(
+            buffer_text(&terminal).contains("starting"),
+            "an empty replay still means nothing has painted"
+        );
+
+        // First real bytes: the notice gives way to the PTY screen.
+        hse(
+            &mut app,
+            ServerEvent::Output {
+                session: sref,
+                seq: 0,
+                data: b"hello from the agent".to_vec(),
+            },
+        );
+        terminal.draw(|f| ui::draw(f, &mut app)).unwrap();
+        let text = buffer_text(&terminal);
+        assert!(
+            text.contains("hello from the agent"),
+            "the real screen replaces it:\n{text}"
+        );
+        assert!(
+            !text.contains("starting"),
+            "and the notice is gone:\n{text}"
+        );
+    }
+
+    // ---- the Workspaces column ----
 
     // ---- the Workspaces bar ----
 

--- a/crates/nebula-tui/src/ui.rs
+++ b/crates/nebula-tui/src/ui.rs
@@ -3368,6 +3368,13 @@ fn draw_terminal(f: &mut Frame, app: &mut App, area: Rect) {
             format!("scroll {}", t.scroll),
             Style::default().fg(th.warn).add_modifier(Modifier::BOLD),
         )),
+        // Nothing has come off the PTY yet: the session was reaped while the
+        // user was elsewhere and its CLI is booting. Say so — the blank grid
+        // on its own reads as a hang.
+        Some(t) if !t.painted => Some(Span::styled(
+            "starting…".to_string(),
+            Style::default().fg(th.dim),
+        )),
         Some(_) if app.term_locked => Some(Span::styled(
             "INPUT".to_string(),
             Style::default().fg(th.accent).add_modifier(Modifier::BOLD),
@@ -3385,6 +3392,26 @@ fn draw_terminal(f: &mut Frame, app: &mut App, area: Rect) {
     app.hits.push((inner, HitTarget::TerminalPane));
 
     let links = match &app.term {
+        // Booting: the grid is empty because the CLI hasn't painted yet, so
+        // there is nothing to render and nothing to scan for links. A word
+        // in the middle of the pane beats an unexplained void.
+        Some(term) if !term.painted && !term.exited => {
+            let msg = Paragraph::new(vec![
+                Line::from(""),
+                Line::from(Span::styled(
+                    "starting session…",
+                    Style::default().fg(th.muted).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(""),
+                Line::from(Span::styled(
+                    "booting — the screen appears as soon as it paints",
+                    Style::default().fg(th.dim),
+                )),
+            ])
+            .centered();
+            f.render_widget(msg, inner);
+            (Vec::new(), Vec::new())
+        }
         Some(term) => {
             let screen = term.parser.screen();
             let widget = tui_term::widget::PseudoTerminal::new(screen);

--- a/crates/nebula/tests/e2e_pty.rs
+++ b/crates/nebula/tests/e2e_pty.rs
@@ -3450,9 +3450,21 @@ async fn workspace_scope_is_per_connection() {
     )
     .await
     .unwrap();
+    // Wait for the upsert itself, not just the Ack: the Ack is written from
+    // the request loop and the upsert from the broadcast forwarder, and the
+    // daemon promises no order between them (the TUI handles either).
+    let is_project_upsert = |e: &ServerEvent| {
+        matches!(
+            e,
+            ServerEvent::EntityUpserted {
+                entity: Entity::Project(_)
+            }
+        )
+    };
     let events = read_events_until(&mut a, Duration::from_secs(5), |evs| {
         evs.iter()
             .any(|e| matches!(e, ServerEvent::Ack { req_id: 3, .. }))
+            && evs.iter().any(is_project_upsert)
     })
     .await;
     let project_a = events
@@ -3484,9 +3496,19 @@ async fn workspace_scope_is_per_connection() {
     )
     .await
     .unwrap();
+    let repo_b_canon = repo_b.canonicalize().unwrap();
+    let is_repo_b_upsert = |e: &ServerEvent| {
+        matches!(
+            e,
+            ServerEvent::EntityUpserted {
+                entity: Entity::Project(p)
+            } if p.repo_path == repo_b_canon
+        )
+    };
     let events = read_events_until(&mut b, Duration::from_secs(5), |evs| {
         evs.iter()
             .any(|e| matches!(e, ServerEvent::Ack { req_id: 4, .. }))
+            && evs.iter().any(is_repo_b_upsert)
     })
     .await;
     let project_b = events
@@ -3494,7 +3516,7 @@ async fn workspace_scope_is_per_connection() {
         .find_map(|e| match e {
             ServerEvent::EntityUpserted {
                 entity: Entity::Project(p),
-            } if p.repo_path == repo_b.canonicalize().unwrap() => Some(p.clone()),
+            } if p.repo_path == repo_b_canon => Some(p.clone()),
             _ => None,
         })
         .expect("AddProject upserts the project");


### PR DESCRIPTION
## Summary

Switching workspaces could leave the terminal pane blank for 5–10s. Three compounding causes, all confirmed against the live dev daemon log and DB:

1. **Every switch attached a dead session.** `session_idle_timeout` (5m) reaps everything in a workspace nobody is looking at, so switching back always landed on a reaped session and the daemon cold-spawned `zsh -l -i -c 'exec claude --resume …'` — with an empty replay, so the pane showed nothing. One fresh `claude` under a login shell measures 0.67s to first byte, 1.47s to a painted screen.
2. **250ms later the prewarm booted every other dead session in the worktree, inline** on the connection's request loop. Five agents → five concurrent CLI boots contending with the one the user was waiting on, and that client's `Input` frames stalled for the whole burst.
3. **`attach` had no debounce.** In the Workspaces column every cursor step is a full `switch_workspace`, so walking past four workspaces cold-booted four CLIs and abandoned three.

### Fixes

- **Daemon:** `ensure_session` holds a `spawn_gate` across its check-and-install, so an Attach and the prewarm sweep racing the same dead session fork one CLI, not two. That lets the sweep leave the request loop: `run_worktree_prewarm` runs on its own task, boots one session per `PREWARM_STAGGER` (1.5s), skips ones already alive, and is aborted by a newer sweep.
- **TUI:** selection-driven attaches wait out `ATTACH_DEBOUNCE` (180ms). The pane swaps immediately; only the `Attach` waits. Explicit picks — Enter, click, menu, palette, a freshly created session, the post-delete reconcile, and the boot snapshot — go through `attach_now` and don't wait. `attached_sref` tracks what the daemon actually holds while `term.sref` runs ahead.
- **UI:** the pane says `starting…` instead of rendering a blank grid, so a boot no longer reads as a hang.

### Also in this PR

**Keep a worktree row on its branch while a rebase is paused** (`95c0a18`). Found while rebasing this branch: a rebase parks HEAD on the commits it replays, so `git worktree list --porcelain` prints `detached` for as long as it sits on a conflict. The worktree sync renamed the row to `detached @ <sha>` and back — and since `nebula worktree <name>` finds rows by branch string, it would have tried to create a *second* checkout for the branch in the meantime. `list_worktrees` now reads `<git-dir>/rebase-merge/head-name` (the same file `git status` uses to say "rebasing branch X") before falling back to the detached label.

**Wait for the upsert in `workspace_scope_is_per_connection`.** The e2e test read events until the `AddProject` Ack and expected the project upsert among them, but the daemon writes the Ack from the request loop and the upsert from the broadcast forwarder and promises no order (the TUI handles either). The memory log had this test losing that race twice under load; a timing shift from the `git.rs` change made it lose ~60% of idle runs even though the new code path never executes in that test. It now waits for both, as `cli_add_project` already did — 10/10 after, 4/11 before.

### Rebase notes

The branch was cut at v0.9.0 and rebased onto v0.13.0, then again onto `8f56ca6`. Two semantic conflicts, both resolved the same way — main factored a path into a helper, and the branch's hook moved into the helper so it covers every caller:

- `main` added `mark_agent_seen` at the top of `attach()`; after the debounce split that funnel is `attach_inner`, so the call moved there — keyed to the pane swap, not the Attach, since the user is reading the screen during the debounce.
- `main` extracted the input-lock into `enter_terminal_pane`, shared by Enter and the new Tab/^⇧L panel walk. `fire_pending_attach` now lives inside it, so landing on the pane by either route settles a debounced attach before the first keystroke.

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — 693 passed, 0 failed, exit 0 on the rebase onto `8f56ca6` (all binaries incl. e2e_pty 25 / e2e_tui 5)
- [x] New: `walking_the_workspaces_column_attaches_only_where_it_stops`, `a_paused_rebase_keeps_the_worktree_on_its_branch`
- [x] `workspace_scope_is_per_connection` 10/10 idle runs
- [x] `cargo fmt --check` clean; clippy shows only the 7 warnings already on `main` (verified the warned lines are untouched by this diff)
- [ ] Manual: switch between workspaces in the live TUI — expect `starting…` instead of a blank pane, and one CLI boot per stop rather than per row passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
