### PR TITLE
A session going red rings a FEEDBACK SOUND and notifies an unfocused desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ HARNESS BADGE normally sits. Walking the cursor onto a SESSION previews it, whic
 count down as you go and disappear at zero. The flag lives in the DAEMON, so it survives closing the TUI
 and is shared by every client; a turn that finishes in the pane you're already looking at never counts.
 
+A dot going red is the one you can't afford to miss — a blocked agent burns the clock while you're in
+another window — so that one reaches you: the FEEDBACK SOUND rings (`Sosumi` by default, distinct from
+the `Glass` DONE SOUND a finish gets), and when the terminal window is in the background a desktop
+notification names the session and its worktree. Neither fires for the pane you're locked into typing
+at with the window focused — that prompt is already under your hands. One setting, `feedback_sound`,
+owns both; `off` silences the pair. See [Configuration](docs/configuration.md).
+
 ## Where the status actually comes from
 
 nebula doesn't poll the agents and it doesn't guess from the screen. At spawn it merges MANAGED HOOKS

--- a/crates/nebula-tui/src/app.rs
+++ b/crates/nebula-tui/src/app.rs
@@ -1876,6 +1876,17 @@ pub struct PreviewedPr {
 /// coalesce those while still beating the steady beat by a wide margin.
 pub const OPEN_PRS_MIN_AGE: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// One session that stopped to ask the user, as the desktop notification
+/// names it: the row's name and where it runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeedbackAlert {
+    /// The session row's name.
+    pub session: String,
+    /// `<project> · <branch>`, the worktree it runs in; empty when the tree
+    /// no longer holds them.
+    pub place: String,
+}
+
 pub struct App {
     pub tree: Tree,
     pub focus: Focus,
@@ -2047,6 +2058,19 @@ pub struct App {
     /// the DONE SOUND (`Config::done_sound`) once and clears it — once per
     /// frame however many rows finished together.
     pub pending_ding: bool,
+    /// Sessions that reached NEEDS FEEDBACK since the last frame, one entry
+    /// each: the main loop rings the FEEDBACK SOUND (`Config::feedback_sound`)
+    /// once for the lot, posts a desktop notification per entry while the
+    /// terminal window is in the background, and clears it. A session whose
+    /// pane the user is locked into typing at, window focused, is never
+    /// queued — that prompt is already in front of them.
+    pub pending_feedback: Vec<FeedbackAlert>,
+    /// Whether the terminal window has focus, from the focus reports
+    /// (mode 1004) `setup_terminal` asks for. True until the terminal says
+    /// otherwise, so one that never reports (tmux without `focus-events`)
+    /// keeps every desktop notification off rather than posting them while
+    /// the user is looking.
+    pub window_focused: bool,
     /// Body rect (everything above the footer) from the last draw; bounds
     /// splitter drags.
     pub body_area: Rect,
@@ -2214,6 +2238,8 @@ impl App {
             pointer_shape: PointerShape::default(),
             pending_clipboard: None,
             pending_ding: false,
+            pending_feedback: Vec::new(),
+            window_focused: true,
             body_area: Rect::default(),
             hostname: nebula_core::host::hostname(),
             is_remote: nebula_core::host::is_remote_session(),

--- a/crates/nebula-tui/src/config.rs
+++ b/crates/nebula-tui/src/config.rs
@@ -22,14 +22,15 @@ pub const SESSION_IDLE_TIMEOUTS: &[&str] = &["off", "1m", "5m", "15m", "30m", "1
 /// models, hand-edited configs can name any command the list doesn't.
 pub const EDITORS: &[&str] = &["vim", "nvim", "nano", "emacs", "hx"];
 
-/// Values the settings overlay cycles through for `done_sound` — what rings
-/// when a turn reaches FINISHED. `off` is silence, `bell` the terminal BEL
+/// Values the settings overlay cycles through for `done_sound` (what rings
+/// when a turn reaches FINISHED) and `feedback_sound` (what rings when one
+/// stops at NEEDS FEEDBACK). `off` is silence, `bell` the terminal BEL
 /// (the one sound that reaches the local terminal over `nebula ssh` — but
 /// silent in Ghostty out of the box, whose `bell-features` default to
 /// `no-audio`), the rest are macOS system sounds in `/System/Library/Sounds`,
 /// played with `afplay`; see [`Config::done_sound`] for where a name falls
 /// back to the bell. Hand-edited configs can name any sound in that folder.
-pub const DONE_SOUNDS: &[&str] = &[
+pub const SOUNDS: &[&str] = &[
     "off",
     "bell",
     "Glass",
@@ -196,6 +197,7 @@ pub enum SettingKind {
     SkipSessionNaming,
     SessionIdleTimeout,
     DoneSound,
+    FeedbackSound,
     Theme,
     Animations,
     ShowWorkspaces,
@@ -270,6 +272,12 @@ pub const SETTINGS_TABS: &[SettingsTab] = &[
                 kind: SettingKind::DoneSound,
                 label: "Done sound",
                 hint: "Ding when a turn finishes: off, the terminal bell, or a macOS system sound",
+                group: "",
+            },
+            SettingSpec {
+                kind: SettingKind::FeedbackSound,
+                label: "Feedback sound",
+                hint: "Ring, and notify an unfocused window, when a turn stops to ask you (off silences both)",
                 group: "",
             },
         ]),
@@ -586,10 +594,17 @@ pub struct Config {
     pub session_idle_timeout: String,
     /// What rings when a turn reaches FINISHED: "off", "bell" (terminal
     /// BEL) or the name of a macOS system sound (`Glass` by default,
-    /// `Ping`, …; see [`DONE_SOUNDS`]). Resolved by [`Config::done_sound`],
+    /// `Ping`, …; see [`SOUNDS`]). Resolved by [`Config::done_sound`],
     /// which falls back to the bell wherever `afplay` can't reach the
     /// user's speakers.
     pub done_sound: String,
+    /// What rings when a turn stops at NEEDS FEEDBACK — a permission
+    /// prompt or a question the agent is parked on. Same values and
+    /// resolution as `done_sound`; `Sosumi` by default so red and green
+    /// sound different from the next room. The one knob for both the
+    /// FEEDBACK SOUND and the desktop notification an unfocused terminal
+    /// window gets: "off" silences the pair.
+    pub feedback_sound: String,
     /// Color theme name (see `theme::THEMES`). Unknown names fall back to
     /// the default theme.
     pub theme: String,
@@ -679,6 +694,7 @@ impl Default for Config {
             skip_session_naming: false,
             session_idle_timeout: "5m".into(),
             done_sound: "Glass".into(),
+            feedback_sound: "Sosumi".into(),
             theme: "default".into(),
             animations: true,
             show_workspaces: true,
@@ -793,6 +809,10 @@ impl Config {
             serde_json::json!(self.session_idle_timeout),
         );
         obj.insert("done_sound".into(), serde_json::json!(self.done_sound));
+        obj.insert(
+            "feedback_sound".into(),
+            serde_json::json!(self.feedback_sound),
+        );
         obj.insert("theme".into(), serde_json::json!(self.theme));
         obj.insert("animations".into(), serde_json::json!(self.animations));
         obj.insert(
@@ -949,6 +969,7 @@ impl Config {
             SettingKind::SkipSessionNaming => on_off(self.skip_session_naming).into(),
             SettingKind::SessionIdleTimeout => self.session_idle_timeout.clone(),
             SettingKind::DoneSound => self.done_sound.clone(),
+            SettingKind::FeedbackSound => self.feedback_sound.clone(),
             SettingKind::Theme => self.theme.clone(),
             SettingKind::Animations => on_off(self.animations).into(),
             SettingKind::ShowWorkspaces => on_off(self.show_workspaces).into(),
@@ -1007,7 +1028,10 @@ impl Config {
                     cycle_choice(&self.session_idle_timeout, SESSION_IDLE_TIMEOUTS, step).into();
             }
             SettingKind::DoneSound => {
-                self.done_sound = cycle_choice(&self.done_sound, DONE_SOUNDS, step).into();
+                self.done_sound = cycle_choice(&self.done_sound, SOUNDS, step).into();
+            }
+            SettingKind::FeedbackSound => {
+                self.feedback_sound = cycle_choice(&self.feedback_sound, SOUNDS, step).into();
             }
             SettingKind::Theme => {
                 self.theme = cycle_choice(&self.theme, crate::theme::THEMES, step).into();
@@ -1089,10 +1113,10 @@ impl Config {
     }
 }
 
-/// What the TUI plays when a turn reaches FINISHED — the `done_sound`
-/// SETTING resolved against where the TUI is running.
+/// What the TUI plays for a status edge — the `done_sound` or
+/// `feedback_sound` SETTING resolved against where the TUI is running.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DoneSound {
+pub enum Sound {
     /// The terminal BEL (`\x07`), written through the attached terminal,
     /// which decides whether that is a sound, a flash, or a dock bounce.
     Bell,
@@ -1106,33 +1130,45 @@ impl Config {
     /// terminal, and when the file exists — over ssh `afplay` would ring
     /// the *remote* box, so the bell stands in there, as it does off
     /// macOS and for a name the sound folder doesn't hold.
-    pub fn done_sound(&self) -> Option<DoneSound> {
-        resolve_done_sound(
+    pub fn done_sound(&self) -> Option<Sound> {
+        resolve_sound(
             &self.done_sound,
+            nebula_core::host::is_remote_session(),
+            cfg!(target_os = "macos"),
+        )
+    }
+
+    /// The sound to play when a turn stops to ask the user, or `None` for
+    /// silence — which also stands down the desktop notification, since
+    /// `feedback_sound` is the one switch for both. Same fallbacks as
+    /// [`Config::done_sound`].
+    pub fn feedback_sound(&self) -> Option<Sound> {
+        resolve_sound(
+            &self.feedback_sound,
             nebula_core::host::is_remote_session(),
             cfg!(target_os = "macos"),
         )
     }
 }
 
-fn resolve_done_sound(configured: &str, remote: bool, macos: bool) -> Option<DoneSound> {
+fn resolve_sound(configured: &str, remote: bool, macos: bool) -> Option<Sound> {
     let name = configured.trim();
     if name.is_empty() || name.eq_ignore_ascii_case("off") {
         return None;
     }
     if name.eq_ignore_ascii_case("bell") || remote || !macos {
-        return Some(DoneSound::Bell);
+        return Some(Sound::Bell);
     }
     // A sound name is a bare file stem; anything else (a path, a dot) is
     // not one, and the bell covers the typo.
     if !name.chars().all(|c| c.is_ascii_alphanumeric()) {
-        return Some(DoneSound::Bell);
+        return Some(Sound::Bell);
     }
     let path = Path::new(MACOS_SOUNDS_DIR).join(format!("{name}.aiff"));
     if path.is_file() {
-        Some(DoneSound::File(path))
+        Some(Sound::File(path))
     } else {
-        Some(DoneSound::Bell)
+        Some(Sound::Bell)
     }
 }
 
@@ -1342,37 +1378,79 @@ mod tests {
         assert_eq!(load_from(&path).done_sound, "Glass");
 
         // Silence, the bell, and every reason a name falls back to it.
-        assert_eq!(resolve_done_sound("off", false, true), None);
-        assert_eq!(resolve_done_sound("OFF", false, true), None);
-        assert_eq!(resolve_done_sound("", false, true), None);
+        assert_eq!(resolve_sound("off", false, true), None);
+        assert_eq!(resolve_sound("OFF", false, true), None);
+        assert_eq!(resolve_sound("", false, true), None);
+        assert_eq!(resolve_sound("bell", false, true), Some(Sound::Bell));
         assert_eq!(
-            resolve_done_sound("bell", false, true),
-            Some(DoneSound::Bell)
-        );
-        assert_eq!(
-            resolve_done_sound("Glass", true, true),
-            Some(DoneSound::Bell),
+            resolve_sound("Glass", true, true),
+            Some(Sound::Bell),
             "over ssh afplay would ring the remote box"
         );
         assert_eq!(
-            resolve_done_sound("Glass", false, false),
-            Some(DoneSound::Bell),
+            resolve_sound("Glass", false, false),
+            Some(Sound::Bell),
             "no system sounds off macOS"
         );
+        assert_eq!(resolve_sound("NoSuchSound", false, true), Some(Sound::Bell));
         assert_eq!(
-            resolve_done_sound("NoSuchSound", false, true),
-            Some(DoneSound::Bell)
-        );
-        assert_eq!(
-            resolve_done_sound("../etc/passwd", false, true),
-            Some(DoneSound::Bell)
+            resolve_sound("../etc/passwd", false, true),
+            Some(Sound::Bell)
         );
         #[cfg(target_os = "macos")]
         assert_eq!(
-            resolve_done_sound("Glass", false, true),
-            Some(DoneSound::File(
-                Path::new(MACOS_SOUNDS_DIR).join("Glass.aiff")
-            ))
+            resolve_sound("Glass", false, true),
+            Some(Sound::File(Path::new(MACOS_SOUNDS_DIR).join("Glass.aiff")))
+        );
+    }
+
+    #[test]
+    fn feedback_sound_defaults_to_sosumi_cycles_persists_and_resolves() {
+        let mut cfg = Config::default();
+        assert_eq!(cfg.feedback_sound, "Sosumi");
+        assert_ne!(
+            cfg.feedback_sound, cfg.done_sound,
+            "red and green must sound different"
+        );
+        // A config predating the key rings too.
+        let old: Config = serde_json::from_str("{}").unwrap();
+        assert_eq!(old.feedback_sound, "Sosumi");
+        // …and one that only ever set the done sound keeps it.
+        let old: Config = serde_json::from_str(r#"{"done_sound": "Ping"}"#).unwrap();
+        assert_eq!(old.done_sound, "Ping");
+        assert_eq!(old.feedback_sound, "Sosumi");
+
+        // Its row sits right after the done sound on the Sessions tab.
+        let (tab, row) = locate(SettingKind::FeedbackSound).unwrap();
+        assert_eq!(locate(SettingKind::DoneSound).unwrap(), (tab, row - 1));
+        assert_eq!(SETTINGS_TABS[tab].title, "Sessions");
+        cfg.cycle(tab, row, 1);
+        assert_eq!(cfg.feedback_sound, "Basso");
+        cfg.cycle(tab, row, 1);
+        assert_eq!(cfg.feedback_sound, "off", "the list wraps");
+        cfg.cycle(tab, row, -1);
+        cfg.cycle(tab, row, -1);
+        assert_eq!(cfg.feedback_sound, "Sosumi");
+        assert_eq!(cfg.value_label(SettingKind::FeedbackSound), "Sosumi");
+        assert_eq!(cfg.done_sound, "Glass", "the done sound is its own row");
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        cfg.feedback_sound = "off".into();
+        cfg.save_to(&path).unwrap();
+        let loaded = load_from(&path);
+        assert_eq!(loaded.feedback_sound, "off");
+        assert_eq!(loaded.feedback_sound(), None, "off is silence for both");
+        assert_eq!(loaded.done_sound, "Glass");
+
+        // The same resolution as the done sound: the bell over ssh and off
+        // macOS, silence for off.
+        assert_eq!(resolve_sound("Sosumi", true, true), Some(Sound::Bell));
+        assert_eq!(resolve_sound("Sosumi", false, false), Some(Sound::Bell));
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            resolve_sound("Sosumi", false, true),
+            Some(Sound::File(Path::new(MACOS_SOUNDS_DIR).join("Sosumi.aiff")))
         );
     }
 

--- a/crates/nebula-tui/src/event_loop.rs
+++ b/crates/nebula-tui/src/event_loop.rs
@@ -27,6 +27,7 @@ use ratatui::Terminal;
 use std::io::{BufWriter, Stdout};
 use std::time::Duration;
 
+mod alerts;
 mod focus_walk;
 mod host_terminal;
 mod placeholder;
@@ -502,9 +503,27 @@ async fn main_loop(
 
         // A turn reached FINISHED: ring the DONE SOUND. The bell goes out
         // through the same terminal as the OSC writes above, so over ssh it
-        // rings the terminal the user is sitting at.
+        // rings the terminal the user is sitting at. CONFIG.JSON is read
+        // fresh, like every other setting.
         if std::mem::take(&mut app.pending_ding) {
-            play_done_sound(terminal.backend_mut());
+            if let Some(sound) = crate::config::Config::load().done_sound() {
+                alerts::play_sound(terminal.backend_mut(), sound);
+            }
+        }
+
+        // One or more turns stopped to ask the user: ring the FEEDBACK
+        // SOUND once for the lot and, while the terminal window is in the
+        // background, name each of them in a desktop notification — never
+        // over ssh, where the desktop is the wrong machine's. `off` is
+        // silence for both.
+        let alerts = std::mem::take(&mut app.pending_feedback);
+        if !alerts.is_empty() {
+            if let Some(sound) = crate::config::Config::load().feedback_sound() {
+                alerts::play_sound(terminal.backend_mut(), sound);
+                if !app.window_focused && !app.is_remote {
+                    alerts::notify_desktop(&alerts);
+                }
+            }
         }
 
         for req in out.drain(..) {
@@ -1207,7 +1226,13 @@ fn handle_terminal_event(app: &mut App, event: Event, out: &mut Vec<ClientReques
         Event::Resize(_, _) => app.dirty = true,
         // The terminal window took focus again — most often back from a
         // browser tab where a pull request was just merged or closed.
-        Event::FocusGained => schedule_pull_request_refresh(app),
+        Event::FocusGained => {
+            app.window_focused = true;
+            schedule_pull_request_refresh(app);
+        }
+        // …and left it: from here until it is back, a session that stops
+        // to ask gets a desktop notification, since the pane can't be seen.
+        Event::FocusLost => app.window_focused = false,
         _ => {}
     }
 }
@@ -5747,33 +5772,6 @@ fn base64_encode(bytes: &[u8]) -> String {
     out
 }
 
-/// Ring the DONE SOUND once: a named system sound goes to `afplay`
-/// (detached; a helper thread reaps it so no zombie lingers), anything
-/// else — and an `afplay` that won't start — is the terminal BEL written
-/// through `backend`. Reads CONFIG.JSON fresh, like every other setting.
-fn play_done_sound<W: std::io::Write>(backend: &mut W) {
-    let Some(sound) = crate::config::Config::load().done_sound() else {
-        return;
-    };
-    if let crate::config::DoneSound::File(path) = &sound {
-        use std::process::{Command, Stdio};
-        if let Ok(mut child) = Command::new("afplay")
-            .arg(path)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-        {
-            std::thread::spawn(move || {
-                let _ = child.wait();
-            });
-            return;
-        }
-    }
-    let _ = backend.write_all(b"\x07");
-    let _ = backend.flush();
-}
-
 /// Copy to *this machine's* system clipboard.
 /// macOS: pbcopy. Linux: wl-copy on Wayland, xclip (or xsel) on X11.
 fn copy_to_clipboard(text: &str) -> bool {
@@ -6825,6 +6823,7 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
             // re-sorts those columns too.
             // Every cursor stays on the row it was on.
             let before = selection_snapshot(app);
+            let mut went_red = false;
             if let Some(a) = app.tree.agents.iter_mut().find(|a| a.id == agent) {
                 // The RUNNING / NEEDS FEEDBACK → FINISHED edge — the one
                 // that raises UNSEEN — rings the DONE SOUND, whether or not
@@ -6838,6 +6837,10 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
                 {
                     app.pending_ding = true;
                 }
+                // The edge *into* NEEDS FEEDBACK is the FEEDBACK SOUND's;
+                // a re-stamp of a row already red is not.
+                went_red = status == nebula_core::AgentStatus::NeedsFeedback
+                    && a.status != nebula_core::AgentStatus::NeedsFeedback;
                 a.status = status;
                 a.status_changed_at = changed_at;
                 a.unseen = unseen;
@@ -6851,6 +6854,17 @@ fn handle_server_event(app: &mut App, event: ServerEvent, out: &mut Vec<ClientRe
                 .is_some_and(|t| t.sref == SessionRef::Agent(agent.clone()));
             if unseen && on_screen {
                 mark_agent_seen(app, &agent, out);
+            }
+            // A prompt in the pane the user is locked into typing at, with
+            // the window focused, is already under their hands: a sound
+            // there is noise. Previewing the pane from a panel is not
+            // typing at it, and a window in the background can't be seen —
+            // both ring, and the second is the whole point.
+            let under_hands = on_screen && app.term_locked && app.window_focused;
+            if went_red && !under_hands {
+                if let Some(alert) = alerts::alert_for(&app.tree, &agent) {
+                    app.pending_feedback.push(alert);
+                }
             }
             // Nothing left any list, so this only re-seats the cursors.
             reconcile_selection_inner(app, before, out);
@@ -7322,6 +7336,7 @@ fn clamp_selections(app: &mut App) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::FeedbackAlert;
     use nebula_core::{AgentId, LinkId, ServerEvent, SessionRef};
     use ratatui::backend::TestBackend;
     use ratatui::Terminal;
@@ -7498,6 +7513,131 @@ mod tests {
                 .any(|r| matches!(r, ClientRequest::MarkAgentSeen { id } if *id == a2)),
             "{out:?}"
         );
+    }
+
+    /// The FEEDBACK SOUND queues on the edge into NEEDS FEEDBACK only — not
+    /// on a re-stamp of a row already red, not on the way out to FINISHED
+    /// (that edge is the DONE SOUND's) — and every session that stops in
+    /// one frame is queued once, named as its row reads, so the desktop
+    /// notification can say who and where. The frame's drain rings once
+    /// for the lot.
+    #[test]
+    fn a_turn_stopping_to_ask_queues_the_feedback_alert() {
+        use nebula_core::AgentStatus;
+        let mut app = App::new();
+        seed_tree(&mut app);
+        seed_second_agent(&mut app, AgentStatus::Running);
+        assert!(app.pending_feedback.is_empty(), "the snapshot is silent");
+        let flip = |agent: &str, status: AgentStatus| ServerEvent::StatusChanged {
+            agent: AgentId(agent.into()),
+            status,
+            changed_at: crate::app::now_ms(),
+            unseen: status == AgentStatus::Finished,
+        };
+
+        hse(&mut app, flip("a2", AgentStatus::NeedsFeedback));
+        assert_eq!(
+            app.pending_feedback,
+            vec![FeedbackAlert {
+                session: "agent-2".into(),
+                place: "demo · main".into(),
+            }]
+        );
+        assert!(!app.pending_ding, "waiting on the user is not done");
+
+        hse(&mut app, flip("a2", AgentStatus::NeedsFeedback));
+        assert_eq!(
+            app.pending_feedback.len(),
+            1,
+            "a re-stamp of a red row is silent"
+        );
+
+        app.pending_feedback.clear();
+        hse(&mut app, flip("a2", AgentStatus::Finished));
+        assert!(
+            app.pending_feedback.is_empty(),
+            "leaving red is the done sound's edge"
+        );
+        assert!(app.pending_ding);
+
+        // Two sessions stopping in one frame: two names for the
+        // notification; the drain plays the sound once for both.
+        hse(&mut app, flip("a1", AgentStatus::Running));
+        hse(&mut app, flip("a1", AgentStatus::NeedsFeedback));
+        hse(&mut app, flip("a2", AgentStatus::Running));
+        hse(&mut app, flip("a2", AgentStatus::NeedsFeedback));
+        let names: Vec<_> = app
+            .pending_feedback
+            .iter()
+            .map(|a| a.session.as_str())
+            .collect();
+        assert_eq!(names, ["agent-1", "agent-2"]);
+    }
+
+    /// A turn that stops to ask in the pane the user is locked into typing
+    /// at, terminal window focused, is already in front of them: nothing
+    /// is queued. Previewing that pane from a panel (unlocked) still
+    /// rings — the cursor may be on another row — and so does a locked
+    /// pane in a window that lost focus, which is the whole point.
+    #[test]
+    fn a_red_turn_in_the_pane_you_are_typing_at_is_silent() {
+        use nebula_core::AgentStatus;
+        let mut app = App::new();
+        seed_tree(&mut app);
+        seed_second_agent(&mut app, AgentStatus::Running);
+        let a2 = AgentId("a2".into());
+        let flip = |status: AgentStatus| ServerEvent::StatusChanged {
+            agent: a2.clone(),
+            status,
+            changed_at: crate::app::now_ms(),
+            unseen: false,
+        };
+        app.term = Some(AttachedTerm::new(SessionRef::Agent(a2.clone()), 40, 10));
+        app.focus = Focus::Terminal;
+        app.term_locked = true;
+        assert!(
+            app.window_focused,
+            "a fresh TUI assumes the window has focus"
+        );
+
+        hse(&mut app, flip(AgentStatus::NeedsFeedback));
+        assert!(
+            app.pending_feedback.is_empty(),
+            "the prompt is on screen, under the user's hands"
+        );
+
+        // Unlocked: the pane merely previews it, the user is on the panels.
+        hse(&mut app, flip(AgentStatus::Running));
+        app.term_locked = false;
+        hse(&mut app, flip(AgentStatus::NeedsFeedback));
+        assert_eq!(app.pending_feedback.len(), 1, "previewing is not typing at");
+
+        // Locked, but the terminal window went to the background.
+        app.pending_feedback.clear();
+        hse(&mut app, flip(AgentStatus::Running));
+        app.term_locked = true;
+        let mut out = Vec::new();
+        handle_terminal_event(&mut app, Event::FocusLost, &mut out);
+        assert!(!app.window_focused);
+        hse(&mut app, flip(AgentStatus::NeedsFeedback));
+        assert_eq!(
+            app.pending_feedback.len(),
+            1,
+            "nobody is looking at that pane"
+        );
+        handle_terminal_event(&mut app, Event::FocusGained, &mut out);
+        assert!(app.window_focused);
+
+        // Another session's pane on screen, locked, makes no difference.
+        app.pending_feedback.clear();
+        app.term = Some(AttachedTerm::new(
+            SessionRef::Agent(AgentId("a1".into())),
+            40,
+            10,
+        ));
+        hse(&mut app, flip(AgentStatus::Running));
+        hse(&mut app, flip(AgentStatus::NeedsFeedback));
+        assert_eq!(app.pending_feedback.len(), 1);
     }
 
     /// The badges: project and worktree rows count their unwatched finishes

--- a/crates/nebula-tui/src/event_loop/alerts.rs
+++ b/crates/nebula-tui/src/event_loop/alerts.rs
@@ -1,0 +1,198 @@
+//! The two ways nebula reaches a user who is not looking at it: the DONE
+//! SOUND and FEEDBACK SOUND (`Config::done_sound` / `Config::feedback_sound`,
+//! played here), and the desktop notification a session that stops to ask
+//! posts while the terminal window is in the background. `event_loop.rs`
+//! decides *when* — the status edges, the per-frame drain of
+//! `App::pending_ding` and `App::pending_feedback`, the focus and ssh
+//! gates — this module only does the reaching, and fails soft: an `afplay`
+//! that won't start falls back to the bell, a notifier that is missing or
+//! exits non-zero is a debug line in tui.log.
+
+use crate::app::{FeedbackAlert, Tree};
+use crate::config::Sound;
+use nebula_core::AgentId;
+use std::process::{Command, Stdio};
+
+/// Ring `sound` once: a file goes to `afplay` (detached; a helper thread
+/// reaps it so no zombie lingers), the bell — and a file whose `afplay`
+/// won't start — is the BEL written through `backend`, so over ssh it
+/// rings the terminal the user is sitting at.
+pub(super) fn play_sound<W: std::io::Write>(backend: &mut W, sound: Sound) {
+    if let Sound::File(path) = &sound {
+        if let Ok(mut child) = Command::new("afplay")
+            .arg(path)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            std::thread::spawn(move || {
+                let _ = child.wait();
+            });
+            return;
+        }
+    }
+    let _ = backend.write_all(b"\x07");
+    let _ = backend.flush();
+}
+
+/// The alert for `agent`, as its row reads on screen: the session's name
+/// and `<project> · <branch>`. `None` for a row the tree doesn't hold (a
+/// status that raced a delete).
+pub(super) fn alert_for(tree: &Tree, agent: &AgentId) -> Option<FeedbackAlert> {
+    let a = tree.agents.iter().find(|a| a.id == *agent)?;
+    let worktree = tree.worktrees.iter().find(|w| w.id == a.worktree_id);
+    let project = worktree.and_then(|w| tree.projects.iter().find(|p| p.id == w.project_id));
+    let place = match (project, worktree) {
+        (Some(p), Some(w)) => format!("{} · {}", p.name, w.branch),
+        (None, Some(w)) => w.branch.clone(),
+        _ => String::new(),
+    };
+    Some(FeedbackAlert {
+        session: a.name.clone(),
+        place,
+    })
+}
+
+/// Post one desktop notification per alert — `osascript` on macOS,
+/// `notify-send` elsewhere — detached, reaped on a helper thread. A
+/// notifier that is missing or exits non-zero is logged at debug and
+/// otherwise ignored: the sound already rang, and a box with no desktop is
+/// not an error.
+pub(super) fn notify_desktop(alerts: &[FeedbackAlert]) {
+    for alert in alerts {
+        let (program, args) = notifier_command(alert, cfg!(target_os = "macos"));
+        match Command::new(program)
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                std::thread::spawn(move || match child.wait() {
+                    Ok(status) if !status.success() => {
+                        tracing::debug!(program, %status, "desktop notification not posted");
+                    }
+                    Err(err) => tracing::debug!(program, %err, "desktop notification not reaped"),
+                    Ok(_) => {}
+                });
+            }
+            Err(err) => tracing::debug!(program, %err, "desktop notification not posted"),
+        }
+    }
+}
+
+/// The notifier to run for `alert`, as a program and its argv — never a
+/// shell line, so the only quoting is AppleScript's own. macOS shows
+/// *nebula* / *`<session>` needs feedback* / *`<project> · <branch>`*;
+/// `notify-send` gets the same as app name, summary and body.
+fn notifier_command(alert: &FeedbackAlert, macos: bool) -> (&'static str, Vec<String>) {
+    let summary = format!("{} needs feedback", alert.session);
+    if macos {
+        let mut script = format!(
+            "display notification {} with title \"nebula\" subtitle {}",
+            applescript_str(&alert.place),
+            applescript_str(&summary)
+        );
+        if alert.place.is_empty() {
+            // No body to show: the subtitle carries the whole message.
+            script = format!(
+                "display notification {} with title \"nebula\"",
+                applescript_str(&summary)
+            );
+        }
+        ("osascript", vec!["-e".into(), script])
+    } else {
+        (
+            "notify-send",
+            vec!["--app-name=nebula".into(), summary, alert.place.clone()],
+        )
+    }
+}
+
+/// `s` as an AppleScript string literal: backslashes and double quotes
+/// escaped, control characters dropped — a session name is one line.
+fn applescript_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            c if c.is_control() => {}
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn alert(session: &str, place: &str) -> FeedbackAlert {
+        FeedbackAlert {
+            session: session.into(),
+            place: place.into(),
+        }
+    }
+
+    /// A session name is user text — a quote or a backslash in it must
+    /// not break out of the AppleScript literal, and a newline can't make
+    /// the script two statements.
+    #[test]
+    fn applescript_literals_are_escaped() {
+        assert_eq!(applescript_str("agent-2"), r#""agent-2""#);
+        assert_eq!(
+            applescript_str(r#"say "hi" \ now"#),
+            r#""say \"hi\" \\ now""#
+        );
+        assert_eq!(applescript_str("one\ntwo\ttab"), r#""onetwotab""#);
+        assert_eq!(applescript_str("demo · main"), r#""demo · main""#);
+    }
+
+    /// The macOS notifier is `osascript -e <one display notification>`,
+    /// nebula as the title, the session as the subtitle, the place as the
+    /// body — and just the session when there is no place to name. Linux
+    /// gets `notify-send` with the same three under its own names.
+    #[test]
+    fn notifier_command_names_the_session_and_its_place() {
+        let (program, args) = notifier_command(&alert("Fix Login", "demo · main"), true);
+        assert_eq!(program, "osascript");
+        assert_eq!(
+            args,
+            [
+                "-e",
+                r#"display notification "demo · main" with title "nebula" subtitle "Fix Login needs feedback""#,
+            ]
+        );
+
+        let (_, args) = notifier_command(&alert("agent-2", ""), true);
+        assert_eq!(
+            args[1],
+            r#"display notification "agent-2 needs feedback" with title "nebula""#
+        );
+
+        let (program, args) = notifier_command(&alert("Fix Login", "demo · main"), false);
+        assert_eq!(program, "notify-send");
+        assert_eq!(
+            args,
+            [
+                "--app-name=nebula",
+                "Fix Login needs feedback",
+                "demo · main"
+            ]
+        );
+    }
+
+    /// The bell path writes exactly one BEL through the backend; `off` is
+    /// the caller's business (a `None` never reaches here).
+    #[test]
+    fn the_bell_is_one_bel_byte() {
+        let mut out = Vec::new();
+        play_sound(&mut out, Sound::Bell);
+        assert_eq!(out, b"\x07");
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ convenience stores: missing or malformed reads as empty.
 
 ## Every setting
 
-Twenty-seven keys. **Overlay** is the SETTINGS OVERLAY tab whose row edits the key; `—` means the key
+Thirty-two keys. **Overlay** is the SETTINGS OVERLAY tab whose row edits the key; `—` means the key
 exists only in the file, so it is hand-edit-only. The Agents tab groups its rows under **Quick prompt**,
 **Claude**, **Codex** and **Cursor** headers, so a harness's rows read `Enabled` / `Model` / `Effort`
 under its name rather than repeating it. The **Experimental** tab holds behaviors that change how the
@@ -39,6 +39,7 @@ tree is worked; every row there is off by default.
 | `skip_session_naming` | bool | `false` | Sessions | New AGENTS launch straight from the NEW SESSION PICKER with no name prompt, taking the generated name and opting into AUTO-TITLE — exactly as accepting an empty prompt does. |
 | `session_idle_timeout` | string | `"5m"` | Sessions | DAEMON-owned IDLE TIMEOUT: how long a session in a WORKTREE no client is viewing goes unwatched before the IDLE REAPER kills its PTY. See the values below. |
 | `done_sound` | string | `"Glass"` | Sessions | The DONE SOUND rung when a turn reaches FINISHED: `off`, `bell` (the terminal BEL — silent in Ghostty unless its `bell-features` include `audio`), or a macOS system sound from `/System/Library/Sounds` played with `afplay` (`Glass`, `Ping`, `Pop`, `Hero`, …). Over `nebula ssh` and off macOS it is always the bell. |
+| `feedback_sound` | string | `"Sosumi"` | Sessions | The FEEDBACK SOUND rung when a turn stops at NEEDS FEEDBACK — a permission prompt or a question — with the same values and fallbacks as `done_sound`, and a different default so red and green sound different from the next room. It never rings for the session whose pane you are locked into typing at while the terminal window has focus: that prompt is already under your hands. The one switch for the DESKTOP NOTIFICATION too: while the terminal window is in the background (from the focus reports nebula asks the terminal for — tmux needs `focus-events on`), each session that goes red is also named in a desktop notification (`osascript` on macOS, `notify-send` on Linux; never over `nebula ssh`, where the desktop is the wrong machine's; a notifier that is missing or fails is a debug line, not an error). `off` silences the sound and the notification together. |
 | `theme` | string | `"default"` | Appearance | The THEME: `default`, `ocean`, `forest`, `rose`, `amber`. An unknown name falls back to `default`. |
 | `animations` | bool | `true` | Appearance | Master switch for the STATUS SWEEP and the SPLASH's motion. Off trades them for fewer repaints on a constrained machine. |
 | `show_workspaces` | bool | `true` | Appearance | Whether the WORKSPACES BAR is drawn across the top. `Shift+W` writes the key as it toggles, so a hidden bar stays hidden across restarts. |
@@ -100,7 +101,10 @@ on the next ATTACH or prewarm, and an agent RESUMES its conversation there.
   and reasoning effort, the idle timeout, the done sound (`done_sound`: a ding
   when a turn finishes — a macOS system sound such as `Glass`, the default; `bell` for the terminal
   bell, which Ghostty keeps silent unless its `bell-features` include `audio`; or `off`. Over
-  `nebula ssh` and off macOS it is always the bell), and whether new sessions stop to ask for a
+  `nebula ssh` and off macOS it is always the bell), the feedback sound (`feedback_sound`: the same
+  choices, `Sosumi` by default, rung when a turn stops to ask you — and, while the terminal window
+  is in the background, a desktop notification naming the session and its worktree; `off` silences
+  both), and whether new sessions stop to ask for a
   name. `R` inside the overlay puts every setting — hotkeys included — back to its default, after a
   confirmation.
 - **Every panel key is rebindable.** The overlay's Hotkeys tab lists every action and what it answers to,


### PR DESCRIPTION
A blocked agent is the expensive state — it burns the clock while you are in another window — and until now it reached nobody, since the only sound nebula made was the DONE SOUND on FINISHED; now the edge into NEEDS FEEDBACK rings a FEEDBACK SOUND of its own (`Sosumi` by default) and, while the terminal window is in the background, posts a desktop notification naming the session and its worktree.

**Contents:** [1. The problem](#user-content-1-the-problem) · [2. What changed](#user-content-2-what-changed) · [3. How it looks](#user-content-3-how-it-looks) · [4. How it works](#user-content-4-how-it-works) · [5. Risk](#user-content-5-risk) · [6. Technical overview](#user-content-6-technical-overview) · [7. Notes](#user-content-7-notes)

## 1. The problem <a id="1-the-problem"></a>

You start an agent, lock into its pane, and go read a pull request in the browser. Two minutes in it hits a permission prompt and stops. The STATUS DOT goes red on a screen you are not looking at, and nothing else happens: the DONE SOUND is for FINISHED, and a red dot never made a sound. A finished turn can wait for you; a permission prompt is the agent waiting for you, with the clock running the whole time.

## 2. What changed <a id="2-what-changed"></a>

- **A FEEDBACK SOUND, distinct from the done sound.** `Settings › Sessions › feedback_sound`, the row right under `done_sound`.
  - Rings when a session reaches NEEDS FEEDBACK — a permission prompt, an `AskUserQuestion`, a Pi extension prompt.
  - Same values as the done sound: `off`, `bell`, or a macOS system sound from `/System/Library/Sounds` played with `afplay`; over `nebula ssh` and off macOS it is the terminal bell, as the done sound is.
  - Default `Sosumi` — unmistakably not `Glass`, so red and green sound different from the next room (`Ping` and `Glass` are both short chimes and blur together).
  - Once per frame however many sessions went red together; a re-stamp of a row already red is silent, and the way out to FINISHED is the done sound's edge, not this one.
- **A desktop notification when the window is in the background.** nebula already asks the terminal for focus reports; they now drive this.
  - macOS: a banner titled **nebula**, subtitle *`<session>` needs feedback*, body *`<project>` · `<branch>`*. Linux: the same through `notify-send` when it is on the PATH.
  - Only while the terminal window has lost focus — a window you are looking at gets the sound alone — and never over `nebula ssh`, where the desktop is the wrong machine's.
  - Fail soft: a notifier that is missing or exits non-zero is a debug line in `tui.log`, nothing on screen. The sound already rang.
- **Never for the pane under your hands.** The session whose pane you are locked into typing at, with the window focused, rings nothing — that prompt is already in front of you.
  - Previewing that pane from a panel (unlocked) still rings: the cursor may be on another row.
  - A locked pane in a window that lost focus still rings and notifies — this is the case the feature exists for, and the brief's literal "never for the locked pane" would have left the single-agent workflow (lock in, go to the browser, the agent asks) as the one case that got nothing.
  - A terminal that never reports focus (tmux without `focus-events on`) reads as always focused: the rule degrades to the literal one, and no notification is ever posted while you might be looking.
- **One setting for both.** `feedback_sound` set to `off` silences the sound and the notification together.
  - No separate `feedback_notify` bool: the notification is the sound's out-of-window twin, not a second feature — someone who wants silence wants no banners either, and the only case where they would diverge (ring, but never notify) is already what a terminal without focus reports gets.
- **Unchanged.** The DONE SOUND keeps its key, its `Glass` default, its values and its edge; a config predating the new key rings `Sosumi` with no edit. Cursor sessions never go red (`--force`) and so never ring.

## 3. How it looks <a id="3-how-it-looks"></a>

| The Settings overlay's Sessions tab: the new **Feedback sound** row under **Done sound**, with its hint in the footer |
|---|
| ![The Settings overlay open on the Sessions tab, four rows: Skip session naming off, Idle session timeout 5m, Done sound Glass, and the selected Feedback sound Sosumi; the hint below reads "Ring, and notify an unfocused window, when a turn stops to ask you (off silences both)"](https://raw.githubusercontent.com/AgentSystemLabs/nebula/pr-assets/feedback-sound/settings-sessions.png) |

The banner itself is a macOS notification, which the SCREENSHOT HARNESS cannot capture (it photographs the terminal, not the desktop). This is the exact command the TUI runs for a session named `Fix Login` in `demo` on `main`, as the unit test pins it:

```
osascript -e 'display notification "demo · main" with title "nebula" subtitle "Fix Login needs feedback"'
```

## 4. How it works <a id="4-how-it-works"></a>

```mermaid
flowchart LR
  HR[HOOK RECEIVER] -->|"PermissionRequest / AskUserQuestion"| SM[STATUS MACHINE]
  SM -->|"StatusChanged: NEEDS FEEDBACK"| E{"edge into red?"}
  E -->|"row already red"| X1((silent))
  E -->|"locked into that pane<br/>+ window focused"| X2((silent))
  E -->|"otherwise"| Q["App::pending_feedback<br/>one alert per session"]
  Q -->|"drained once per frame"| SND["FEEDBACK SOUND<br/>afplay, or BEL"]
  Q -->|"window unfocused<br/>and not over ssh"| NOTE["desktop notification<br/>osascript / notify-send"]
  FR["terminal focus reports<br/>(mode 1004)"] --> WF["App::window_focused"]
  WF --> E
  WF --> NOTE
  CFG["config.json<br/>feedback_sound"] -->|"off = neither"| SND
  CFG --> NOTE
  classDef changed fill:#fde68a,stroke:#b45309,color:#111
  class E,Q,SND,NOTE,WF,CFG changed
```

## 5. Risk <a id="5-risk"></a>

**Verdict:** 🟢 Low risk — TUI-only, no DAEMON, PROTOCOL or store change; the new code runs one comparison per status event and spawns the same kind of detached helper the done sound already does.

| | Level | Why |
|---|---|---|
| 🔒 **Security & production** | Low | Two process spawns from the TUI: `afplay` (spawned today for the done sound) and `osascript` / `notify-send`. Both are argv, never a shell line; the only user text that reaches them is the session name and branch, passed through AppleScript quoting that a test pins (`"` and `\` escaped, control characters dropped). No new `ClientRequest`, no hook route, no file written, nothing over ssh. |
| ⚡ **Performance** | Low | Off every hot path: the edge check is one status comparison inside the existing `StatusChanged` arm; the per-frame drain is a `mem::take` of a vector that is empty on almost every frame; CONFIG.JSON is read only on a frame with an alert, as the done sound reads it. Spawns are detached and reaped on a thread. A frame with both a green and a red edge starts two `afplay`s. |
| 🧩 **Fit with the codebase** | Low | Mirrors `pending_ding` one for one (set in the handler, drained after the OSC writes); the config row copies `done_sound`'s shape; the new `event_loop/alerts.rs` sits beside `focus_walk.rs` and `host_terminal.rs`. The one departure: the done sound's `DoneSound` / `DONE_SOUNDS` / `resolve_done_sound` are renamed `Sound` / `SOUNDS` / `resolve_sound` because both settings now share them. |

**Rollback:** `git revert` of the merge commit undoes all of it. A `feedback_sound` key the overlay already wrote into `config.json` is skipped by the old code like any unknown field; there is no PROTOCOL VERSION bump and no store migration. The `feedback-sound/` directory on the `pr-assets` branch stays, as every PR's does.

## 6. Technical overview <a id="6-technical-overview"></a>

- **Mechanism.** `Config` gains `feedback_sound: String` (default `"Sosumi"`, `#[serde(default)]` like every key), a `SettingKind::FeedbackSound` row on the Sessions tab, and `Config::feedback_sound() -> Option<Sound>` through the same `resolve_sound` the done sound uses. `App` gains `pending_feedback: Vec<FeedbackAlert>` (`{ session, place }`) and `window_focused: bool` (true until the terminal says otherwise). `handle_server_event`'s `StatusChanged` arm computes `went_red` — new status NEEDS FEEDBACK, old status anything else — and, unless the pane on screen is that session's *and* `term_locked` *and* `window_focused`, pushes `alerts::alert_for(&app.tree, &agent)`. `handle_terminal_event` flips `window_focused` on `FocusGained` / `FocusLost` (the former still schedules the pull-request refresh). The main loop, right after the `pending_ding` block, takes the vector; if non-empty it resolves the sound once, plays it, and — when `!window_focused && !is_remote` — posts one notification per alert.
- **Files.** `crates/nebula-tui/src/config.rs` — the key, the row, the resolver rename, two tests; `crates/nebula-tui/src/app.rs` — `FeedbackAlert`, the two fields; `crates/nebula-tui/src/event_loop.rs` — focus tracking, the edge detection, the per-frame drain, the done sound's play call moved, two tests; `crates/nebula-tui/src/event_loop/alerts.rs` (new) — `play_sound`, `alert_for`, `notify_desktop`, the pure `notifier_command` / `applescript_str` and their tests; `docs/configuration.md`, `README.md`.
- **Why not in the DAEMON.** The DAEMON has neither the terminal's focus state nor a desktop; each attached TUI rings and notifies for itself, exactly as the done sound does today (two TUIs attached is two rings, unchanged).
- **Why not a `feedback_notify` bool.** Fewer settings is the house preference, and the notification has no life of its own: it fires on the sound's trigger, under the sound's gate, and the one configuration it would enable — banners but no sound — is `bell` in a terminal whose bell is silent, which already works.
- **Tests.** Edge detection (RUNNING → red queues; a red re-stamp and red → FINISHED do not; two sessions in a frame queue two names), the locked-pane rule under each focus state and with another session's pane on screen, the config row (default, cycling, persistence, `off` resolving to silence, the bell over ssh / off macOS, the row sitting after `done_sound` on the Sessions tab), AppleScript quoting, and the `osascript` / `notify-send` argv.
- **Gate.** `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets` zero warnings; `cargo test --workspace --lib` 827 passed, 0 failed (12 + 196 + 619 across the workspace's lib targets). `cargo test -p nebula` (the e2e suites) was **not** run: no DAEMON, PROTOCOL or spawn path changed.

## 7. Notes <a id="7-notes"></a>

- Cut from `origin/main` at `c202e6e` (#34); no conflicts. No PROTOCOL VERSION bump, so no `nebula kill` is needed — a running TUI picks the new key up on its next `config.json` read.
- The chosen default is `Sosumi`: the brief asked for a macOS sound distinct from `Glass`, offering `Ping` or `Sosumi`; `Ping` and `Glass` are both short tonal chimes, `Sosumi` is the classic alert and cannot be mistaken for a finish.
- `docs/configuration.md`'s "Every setting" prose said twenty-seven keys over a table of thirty-one; it now says thirty-two, which is what the table holds after this row.
- `docs/keys.md`, `docs/sessions.md` and `docs/how-it-works.md` never mentioned the done sound and are untouched; the `?` help overlay lists keys, not sounds, so it is untouched too. The Settings overlay row comes from the same spec table as every other, so no UI code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTRxKx9hRhQHpDhbi6i92D
