### PR TITLE
Relocated Codex sessions carry on in their worktree without a typed "continue"

### DIFF
--- a/crates/nebula-daemon/src/registry.rs
+++ b/crates/nebula-daemon/src/registry.rs
@@ -1508,10 +1508,11 @@ impl Daemon {
     /// The turn an agent ran `nebula worktree` in has ended: make the
     /// process match its row. Kill it and respawn it resumed in the target,
     /// with a prompt naming the checkout it now runs in so the conversation
-    /// carries straight on (Claude and pi take that prompt as an argument;
-    /// codex and cursor resume silent and wait for the user). Gated on the
-    /// turn-end hooks — Stop, and the idle notification a Stop-less end
-    /// still fires — so a Bash hook from the same turn never triggers it.
+    /// carries straight on (Claude, codex and pi take that prompt as an
+    /// argument; cursor resumes silent and waits for the user — see
+    /// `relocation_prompt`). Gated on the turn-end hooks — Stop, and the
+    /// idle notification a Stop-less end still fires — so a Bash hook from
+    /// the same turn never triggers it.
     pub fn complete_pending_move(self: &Arc<Self>, id: &AgentId, event: &HookEvent) {
         let turn_over = match event {
             HookEvent::Stop => true,
@@ -1541,17 +1542,15 @@ impl Daemon {
         tracing::info!(agent = %id, to = %target.branch, "relocating session into its worktree");
         self.kill_session(&sref);
         self.last_cwd.lock().unwrap().remove(id);
-        // Claude and pi: `claude --resume <sid> "<prompt>"` and
-        // `pi --session-id <sid> "<prompt>"` are verified to open on the
-        // prompt; whether `codex resume` / `cursor-agent --resume` take a
-        // trailing prompt is not, so their relocated sessions keep waiting
-        // for the user.
-        let prompt = relocation_prompt(&target);
-        let prompt =
-            matches!(agent.kind, AgentKind::Claude | AgentKind::Pi).then_some(prompt.as_str());
-        if let Err(e) =
-            self.spawn_agent_session_with(&agent, &target, DEFAULT_COLS, DEFAULT_ROWS, None, prompt)
-        {
+        let prompt = relocation_prompt(agent.kind, &target);
+        if let Err(e) = self.spawn_agent_session_with(
+            &agent,
+            &target,
+            DEFAULT_COLS,
+            DEFAULT_ROWS,
+            None,
+            prompt.as_deref(),
+        ) {
             tracing::warn!(agent = %id, error = %e, "respawn after worktree relocation failed");
         }
         self.try_broadcast_agent(id);
@@ -2463,6 +2462,7 @@ impl Daemon {
             None => agent_spawn_command_with(
                 agent.kind,
                 agent.session_id.as_deref(),
+                Some(&worktree.path),
                 agent.model.as_deref(),
                 agent.effort.as_deref(),
                 cmd_override.as_deref(),
@@ -2722,12 +2722,17 @@ impl Daemon {
 /// Program + args for an agent PTY. An override (tests) is used verbatim —
 /// no resume args. Otherwise the kind picks the CLI and its resume shape:
 /// `claude --resume <sid>` and `cursor-agent --resume <sid>` (flag) vs
-/// `codex resume <sid>` (subcommand, so resume args must lead); pi takes
-/// `pi --session-id <sid>`, which resumes the id where it exists and
-/// creates it where it doesn't (a relocated session's new cwd). Codex and
-/// cursor always get their skip-permissions flag (`--yolo` / `--force`),
-/// appended after the resume args — same convention as Mission Control;
-/// pi has no permission gate to skip.
+/// `codex resume <sid> --cd <cwd>` (subcommand, so resume args must lead;
+/// the `--cd` because codex reopens a resumed session in the directory its
+/// transcript recorded — or asks which to use — unless told one, and a
+/// relocated session must land in its new worktree, not the old checkout);
+/// pi takes `pi --session-id <sid>`, which resumes the id where it exists
+/// and creates it where it doesn't (a relocated session's new cwd). `cwd`
+/// is the checkout every local spawn boots in, and None for a Cloud launch,
+/// which has no local one. Codex and cursor always get their
+/// skip-permissions flag (`--yolo` / `--force`), appended after the resume
+/// args — same convention as Mission Control; pi has no permission gate to
+/// skip.
 /// Model/effort choices follow: `claude --model m --effort e`,
 /// `codex -m m -c model_reasoning_effort=e`, `pi --model m --thinking e`,
 /// and for cursor one flat id
@@ -2742,8 +2747,9 @@ impl Daemon {
 /// (`claude [prompt]`, `codex [PROMPT]`, `cursor-agent [prompt...]`,
 /// `pi [messages...]`).
 ///
-/// The plain shape, as every restart/resume spawns it: no initial prompt,
-/// guidance on. Tests assert against this; the daemon calls the full form.
+/// The plain shape, as every restart/resume spawns it: booted in
+/// `TEST_CWD`, no initial prompt, guidance on. Tests assert against this;
+/// the daemon calls the full form.
 #[cfg(test)]
 fn agent_spawn_command(
     kind: AgentKind,
@@ -2755,6 +2761,7 @@ fn agent_spawn_command(
     agent_spawn_command_with(
         kind,
         session_id,
+        Some(Path::new(TEST_CWD)),
         model,
         effort,
         cmd_override,
@@ -2784,24 +2791,38 @@ tell the user in one line that the session is moving into the worktree, and make
 calls or edits — you will be resumed inside the worktree with a prompt to carry on there. If the \
 command fails, report the error and carry on in the current checkout.";
 
-/// The prompt a relocated Claude session is resumed with: it names the
-/// checkout the process now runs in and asks for the work to pick back up
-/// there, so the user never has to type "continue".
-fn relocation_prompt(worktree: &Worktree) -> String {
-    format!(
-        "[nebula] This session now runs inside the worktree `{}` at {} — your working \
-         directory is that checkout. Continue the user's most recent request there.",
-        worktree.branch,
-        worktree.path.display()
-    )
+/// The prompt a relocated session is resumed with: it names the checkout
+/// the process now runs in and asks for the work to pick back up there, so
+/// the user never has to type "continue". Only for the CLIs verified to
+/// open a resumed session on a trailing prompt — `claude --resume <sid>
+/// "<prompt>"`, `codex resume <sid> [PROMPT]` (the positional its `--help`
+/// documents; submitted as the next turn, verified live on codex 0.153.4)
+/// and `pi --session-id <sid> "<prompt>"`. Whether `cursor-agent --resume
+/// <id> [prompt...]` submits one is not, so a relocated cursor session
+/// resumes silent and waits for the user.
+fn relocation_prompt(kind: AgentKind, worktree: &Worktree) -> Option<String> {
+    match kind {
+        AgentKind::Claude | AgentKind::Codex | AgentKind::Pi => Some(format!(
+            "[nebula] This session now runs inside the worktree `{}` at {} — your working \
+             directory is that checkout. Continue the user's most recent request there.",
+            worktree.branch,
+            worktree.path.display()
+        )),
+        AgentKind::Cursor => None,
+    }
 }
 
-// Eight positional knobs is one over clippy's line; the callers are the two
+/// The checkout the test wrapper boots every spawn in.
+#[cfg(test)]
+const TEST_CWD: &str = "/nebula-test/p-feat";
+
+// Nine positional knobs are two over clippy's line; the callers are the two
 // thin wrappers above and the tests, so a builder would only add ceremony.
 #[allow(clippy::too_many_arguments)]
 fn agent_spawn_command_with(
     kind: AgentKind,
     session_id: Option<&str>,
+    cwd: Option<&Path>,
     model: Option<&str>,
     effort: Option<&str>,
     cmd_override: Option<&str>,
@@ -2820,7 +2841,13 @@ fn agent_spawn_command_with(
     let program = kind.cli_program().to_string();
     let (mut args, resumed) = match (kind, session_id) {
         (AgentKind::Claude, Some(sid)) => (vec!["--resume".to_string(), sid.to_string()], true),
-        (AgentKind::Codex, Some(sid)) => (vec!["resume".to_string(), sid.to_string()], true),
+        (AgentKind::Codex, Some(sid)) => {
+            let mut args = vec!["resume".to_string(), sid.to_string()];
+            if let Some(cwd) = cwd {
+                args.extend(["--cd".to_string(), cwd.to_string_lossy().into_owned()]);
+            }
+            (args, true)
+        }
         (AgentKind::Cursor, Some(sid)) => (vec!["--resume".to_string(), sid.to_string()], true),
         (AgentKind::Pi, Some(sid)) => (vec!["--session-id".to_string(), sid.to_string()], true),
         (_, None) => (Vec::new(), false),
@@ -3001,6 +3028,7 @@ fn claude_cloud_spawn_command(
 ) -> (String, Vec<String>, bool) {
     let (program, mut args, resumed) = agent_spawn_command_with(
         AgentKind::Claude,
+        None,
         None,
         model,
         effort,
@@ -3187,7 +3215,10 @@ mod tests {
             agent_spawn_command(AgentKind::Claude, Some("sid-1"), None, None, None),
             ("claude".into(), guided(&["--resume", "sid-1"]), true)
         );
-        // Skip-permissions flags trail the resume args.
+        // Skip-permissions flags trail the resume args. A codex resume is
+        // told its checkout (`--cd`): without it codex reopens the session
+        // in the directory its transcript recorded, which for a relocated
+        // session is the old one.
         assert_eq!(
             agent_spawn_command(AgentKind::Codex, Some("sid-2"), None, None, None),
             (
@@ -3195,6 +3226,8 @@ mod tests {
                 vec![
                     "resume".to_string(),
                     "sid-2".to_string(),
+                    "--cd".to_string(),
+                    TEST_CWD.to_string(),
                     "--yolo".to_string()
                 ],
                 true
@@ -3335,6 +3368,7 @@ mod tests {
         let (_, args, resumed) = agent_spawn_command_with(
             AgentKind::Claude,
             Some("sid"),
+            Some(Path::new(TEST_CWD)),
             Some("opus"),
             None,
             None,
@@ -3351,6 +3385,7 @@ mod tests {
             agent_spawn_command_with(
                 AgentKind::Codex,
                 Some("sid"),
+                Some(Path::new(TEST_CWD)),
                 None,
                 None,
                 None,
@@ -3359,12 +3394,13 @@ mod tests {
                 true
             )
             .1,
-            vec!["resume", "sid", "--yolo", "carry on"]
+            vec!["resume", "sid", "--cd", TEST_CWD, "--yolo", "carry on"]
         );
         assert_eq!(
             agent_spawn_command_with(
                 AgentKind::Cursor,
                 Some("sid"),
+                Some(Path::new(TEST_CWD)),
                 None,
                 None,
                 None,
@@ -3383,6 +3419,7 @@ mod tests {
             agent_spawn_command_with(
                 AgentKind::Claude,
                 None,
+                Some(Path::new(TEST_CWD)),
                 Some("opus"),
                 Some("high"),
                 None,
@@ -3397,6 +3434,7 @@ mod tests {
             agent_spawn_command_with(
                 AgentKind::Codex,
                 None,
+                Some(Path::new(TEST_CWD)),
                 Some("gpt-5.5"),
                 Some("high"),
                 None,
@@ -3418,6 +3456,7 @@ mod tests {
             agent_spawn_command_with(
                 AgentKind::Cursor,
                 None,
+                Some(Path::new(TEST_CWD)),
                 None,
                 None,
                 None,
@@ -3436,6 +3475,7 @@ mod tests {
             agent_spawn_command_with(
                 AgentKind::Pi,
                 Some("sid"),
+                Some(Path::new(TEST_CWD)),
                 None,
                 None,
                 None,
@@ -3451,6 +3491,7 @@ mod tests {
             agent_spawn_command_with(
                 AgentKind::Claude,
                 None,
+                Some(Path::new(TEST_CWD)),
                 None,
                 None,
                 Some("/bin/sh -i"),
@@ -3459,6 +3500,58 @@ mod tests {
                 true
             ),
             ("/bin/sh".into(), vec!["-i".to_string()], false)
+        );
+    }
+
+    /// The relocation notice reaches the CLIs whose resume submits a
+    /// trailing prompt — Claude, codex and pi — and names the checkout;
+    /// cursor's is unverified, so its relocated session reopens silent.
+    /// (Codex was gated out until #39: `codex resume <id> --yolo` sat at
+    /// Ready in the worktree until the user typed "continue".)
+    #[test]
+    fn relocation_prompt_reaches_every_kind_but_cursor() {
+        let feat = Worktree {
+            id: WorktreeId("feat".into()),
+            project_id: ProjectId("p".into()),
+            path: "/nebula-test/p-feat".into(),
+            branch: "feat".into(),
+            is_main: false,
+            sort_order: 0,
+        };
+        for kind in [AgentKind::Claude, AgentKind::Codex, AgentKind::Pi] {
+            let prompt = relocation_prompt(kind, &feat).unwrap_or_else(|| panic!("{kind:?}"));
+            assert!(prompt.contains("`feat`"), "{kind:?}: {prompt}");
+            assert!(prompt.contains("/nebula-test/p-feat"), "{kind:?}: {prompt}");
+            assert!(prompt.contains("Continue the user's most recent request"));
+        }
+        assert_eq!(relocation_prompt(AgentKind::Cursor, &feat), None);
+
+        // And the codex respawn it feeds: resumed, re-rooted in the
+        // worktree, and opening on the notice.
+        let notice = relocation_prompt(AgentKind::Codex, &feat).unwrap();
+        let (program, args, resumed) = agent_spawn_command_with(
+            AgentKind::Codex,
+            Some("sid"),
+            Some(&feat.path),
+            None,
+            None,
+            None,
+            Some(&notice),
+            None,
+            true,
+        );
+        assert_eq!(program, "codex");
+        assert!(resumed);
+        assert_eq!(
+            args,
+            vec![
+                "resume",
+                "sid",
+                "--cd",
+                "/nebula-test/p-feat",
+                "--yolo",
+                notice.as_str()
+            ]
         );
     }
 
@@ -3474,6 +3567,7 @@ mod tests {
         let (_, args, resumed) = agent_spawn_command_with(
             AgentKind::Claude,
             Some("sid"),
+            Some(Path::new(TEST_CWD)),
             None,
             None,
             None,

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -119,9 +119,12 @@
   worktree, opening with a note saying where it now runs, so the conversation carries on there without
   you typing anything. Claude learns the rule from a short `--append-system-prompt` nebula passes at
   spawn, plus a `Bash(nebula worktree:*)` permission so the command never prompts; Pi gets the same
-  appended prompt and reopens on the same note. Codex and Cursor
-  sessions can run the same command; they resume silent and wait for your next prompt. The restart is
-  the only way there: an agent CLI can't `cd` out of the directory it was started in.
+  appended prompt and reopens on the same note. Codex and Cursor have no system-prompt flag to learn
+  the rule from, but run the same command when you ask. Codex then reopens on the same note —
+  `codex resume <id> --cd <worktree> "<note>"`, the `--cd` because Codex otherwise reopens a resumed
+  session in the directory its transcript recorded, the old checkout. Cursor resumes silent and waits
+  for your next prompt. The restart is the only way there: an agent CLI can't `cd` out of the
+  directory it was started in.
 - **Ask the agent for another session and it starts one.** Tell a Claude session "start a new nebula
   session that fixes the login redirect" and it runs `nebula spawn "<task>"`: the daemon starts a second
   agent beside it — same worktree, same harness, model and effort unless `--kind claude|codex|cursor|pi`


### PR DESCRIPTION
Closes #39. A Codex session that ran `nebula worktree <name>` was restarted in the worktree with no continuation prompt and sat at Ready until you typed `continue`; it now reopens on the same relocation note Claude and Pi get, rooted in the new checkout.

**Contents:** [🐛 Symptom](#user-content-symptom) · [🔍 Cause](#user-content-cause) · [✅ Fix](#user-content-fix) · [📸 Before / After](#user-content-before-after) · [🔁 Flow](#user-content-flow) · [⚠️ Risk](#user-content-risk) · [🔧 Technical overview](#user-content-technical-overview) · [🧪 Proof](#user-content-proof) · [📝 Notes](#user-content-notes)

## 🐛 Symptom <a id="symptom"></a>

*Codex waits for input after worktree relocation instead of continuing.* On the official v0.23.0 release with Codex CLI 0.153.4, a Codex session asked to work in a worktree ran `nebula worktree codex-resume-repro` and ended its turn as instructed. nebula moved the row and restarted the CLI inside the worktree as `codex resume <session-id> --yolo` — the right directory, but no prompt: Codex stayed at Ready for a minute and a half with only the original request in its transcript, and carried on the moment the user typed `continue` by hand. Claude Code in the same spot continues on its own. Thanks @sambu-volkin (#39).

## 🔍 Cause <a id="cause"></a>

The DAEMON's relocation respawn handed the note ("this session now runs inside the worktree … continue the user's most recent request there") to Claude and Pi only. Codex and Cursor were gated out on purpose: whether `codex resume` / `cursor-agent --resume` accepted a trailing prompt had never been verified, so their relocated sessions were left to "resume silent and wait for the user". Codex does accept one — `codex resume [SESSION_ID] [PROMPT]` is in its `--help`, and the positional is submitted as the next turn — so the gate was the whole bug. Underneath it sat a second gap: Codex documents that a resumed session reopens in the directory its transcript recorded (or asks which to use when that differs from the current one) unless `--cd` names a working root. nebula spawned the PTY in the worktree but never told Codex, so nothing held a resumed session to the new checkout.

## ✅ Fix <a id="fix"></a>

- **Codex reopens on the relocation note.** The note is now produced per agent kind, and Codex is in the set with Claude and Pi.
  - the respawn is `codex resume <sid> --cd <worktree> --yolo "<note>"`
  - Codex submits the note as its next turn, in the same session, and picks the request back up in the worktree
  - nothing to type: the conversation carries on as it already did for Claude and Pi
- **Every Codex resume is told its checkout.** `--cd <worktree>` rides each `codex resume`, not only the relocation one.
  - a restart or a failed-resume fallback of a session that once moved can no longer follow its transcript back to the old directory
  - the `--cd` names the same directory the PTY already boots in, so a session that never moved is unaffected
- **Unchanged.** Cursor still resumes silent: `cursor-agent --resume <id> [prompt...]` parses, but whether it submits the prompt is unverified, and the comment now says exactly that.
  - the turn-end boundary stays: the respawn waits for the Stop or idle hook, never a tool hook from the same turn
  - Claude and Pi's respawn shape, and what `nebula worktree` prints to the agent, are untouched

## 📸 Before / After <a id="before-after"></a>

No PNG for this one: it is a DAEMON respawn mechanism with no screen of its own — the whole change is the command line the relocated session is restarted with, so that is what is shown.

**Before (#39)** — the relocated session's process, waiting:

```text
codex resume 9f3c1a2e-…-… --yolo
```

**After** — resumed, re-rooted, and opening on the note:

```text
codex resume 9f3c1a2e-…-… --cd /Users/you/Workspace/repo-worktrees/feat --yolo "[nebula] This session now runs inside the worktree `feat` at /Users/you/Workspace/repo-worktrees/feat — your working directory is that checkout. Continue the user's most recent request there."
```

The new unit test pins the same shape:

```text
test registry::tests::relocation_prompt_reaches_every_kind_but_cursor ... ok
test registry::tests::spawn_command_per_kind_resume_shapes ... ok
test registry::tests::spawn_command_initial_prompt_is_the_trailing_positional_argument ... ok
test nebula_worktree_cli_relocates_the_session_when_the_turn_ends ... ok
```

## 🔁 Flow <a id="flow"></a>

```mermaid
flowchart LR
  A["agent runs<br/>nebula worktree feat"] --> B["turn ends:<br/>Stop or idle_prompt hook"]
  B --> C["DAEMON<br/>complete_pending_move"]
  C --> D{"relocation_prompt(kind)"}
  D -->|Claude · Pi| E["the note"]
  D -->|Codex| E
  D -->|Cursor| F["no prompt"]
  E --> G["argv builder<br/>(kind, sid, cwd, …)"]
  F --> G
  G --> H["claude --resume sid … note"]
  G --> I["codex resume sid --cd worktree --yolo note"]
  G --> J["cursor-agent --resume sid --force"]
  classDef changed fill:#fde68a,stroke:#b45309,color:#111;
  class D,I changed;
```

The highlighted edge is what #39 lacked: before, the Codex branch of the gate joined Cursor's, and the argv builder had no `--cd` to give.

## ⚠️ Risk <a id="risk"></a>

**Verdict:** 🟢 Low risk — two argv changes on the DAEMON's Codex respawn path; no protocol, store, hook or TUI change.

| | Level | Why |
|---|---|---|
| 🔒 **Security & production** | Low | No new surface: the note's text and the worktree path already reached argv for Claude and Pi and take the same login-shell single-quoting for Codex. The one production edge: a Codex CLI too old to take `--cd` or `[PROMPT]` on `resume` would fail the resume and fall to the existing fresh-spawn fallback, keeping the row and losing the conversation. |
| ⚡ **Performance** | Low | Off every hot path: a few strings built once per relocation or restart. |
| 🧩 **Fit with the codebase** | Low | Follows the per-kind argv shape and its unit-test convention; the builder gains one positional (its `too_many_arguments` allow already stood) and the Cloud launch passes `None` for the checkout it does not have. |

**Rollback:** `git revert` of the merge undoes all of it — no PROTOCOL VERSION bump, no store migration. It does not remove the pushed `codex-relocation-prompt` branch.

## 🔧 Technical overview <a id="technical-overview"></a>

- **The line that mattered.** `crates/nebula-daemon/src/registry.rs` — `complete_pending_move` had `matches!(agent.kind, Claude | Pi).then_some(prompt)`; it now calls `relocation_prompt(agent.kind, &target)`, which returns `Some` for Claude, Codex and Pi and `None` for Cursor, and passes the result into `spawn_agent_session_with` as the initial prompt.
- **`--cd`.** `agent_spawn_command_with` takes a `cwd: Option<&Path>` after the session id; the Codex resume arm emits `resume <sid> --cd <cwd>` ahead of `--yolo`, model and effort, with the prompt still last. The daemon passes `Some(&worktree.path)`, `claude_cloud_spawn_command` passes `None` (no local checkout), and the test wrapper boots every spawn in `TEST_CWD`.
- **Why it was missed.** The gate was a recorded "unverified" exclusion rather than an untested path — and the end-to-end relocation test drives a stub CLI under `NEBULA_AGENT_CMD`, which replaces the argv verbatim, so only the argv unit tests can see resume args or the prompt.
- **Why not Cursor too.** Its `--resume [chatId] [prompt...]` is an optional-value flag followed by a positional; it parses, but nothing here shows the prompt being submitted, so it keeps the silent resume with the reason in the comment.
- **Why `--cd` on every Codex resume, not just the relocation.** Any later restart of a session that once moved has the same transcript-recorded directory to fall back to; the resume arm is the one place that covers relocation, restart and the resume fallback alike.
- **Docs.** `docs/how-it-works.md` — the relocation paragraph now says Codex reopens on the note (with the `--cd` and why) and Cursor waits.

## 🧪 Proof <a id="proof"></a>

- **Regression test.** `relocation_prompt_reaches_every_kind_but_cursor` in `crates/nebula-daemon/src/registry.rs` — the note for Claude, Codex and Pi naming the branch and path, `None` for Cursor, and the Codex respawn's argv `resume sid --cd /nebula-test/p-feat --yolo <note>`. On `origin/main` the gate produced neither the prompt nor the `--cd` for Codex. `spawn_command_per_kind_resume_shapes` and `spawn_command_initial_prompt_is_the_trailing_positional_argument` now expect the `--cd` pair.
- **Flag check on Codex 0.153.4.** `codex resume <uuid> --yolo --cd <dir> "hello there" </dev/null` fails only with `Error: stdin is not a terminal` — past argument parsing — while a made-up flag fails with clap's `unexpected argument`; `codex resume --help` lists both `[PROMPT]` and `-C, --cd <DIR>`.
- **Not run here.** A live relocation through nebula with the real Codex CLI was not driven in this session. The reporter ran these same two changes against Codex 0.153.4 on macOS and saw the resumed session continue on the note under the same session id with nothing typed (#39).
- **Gate.** `make ci` green on this branch — `cargo fmt --check`, clippy over the workspace with all targets, and the full `cargo test --workspace` including `e2e_pty` and `e2e_tui` over real daemons: 931 tests, 0 failed.

## 📝 Notes <a id="notes"></a>

- Branched from `origin/main` at v0.23.0 (`c525e05`); one commit, no conflicts expected.
- Thanks @sambu-volkin for the diagnosis, the source pointer and the live validation (#39).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133HB2FrtJvNPd3j7tjzCcZ
