### PR TITLE
No more index.lock collisions under the worktree badge's git poll, and the warm-spare pool gets its Settings rows

### DIFF
--- a/crates/nebula-daemon/src/registry.rs
+++ b/crates/nebula-daemon/src/registry.rs
@@ -1217,15 +1217,24 @@ impl Daemon {
         Some(entry)
     }
 
-    /// Drop warm sessions that died or sat unclaimed past the max age
-    /// (runs on the daemon's periodic tick).
+    /// Drop warm sessions that died or sat unclaimed past the max age —
+    /// and, once `prewarm_agents` is switched off, every one of them: a
+    /// spare is a real CLI process the user can see (Claude's `/list-agents`
+    /// names it beside their own sessions), so the toggle takes it away on
+    /// the next sweep rather than leaving it to age out over 15 minutes.
+    /// Runs on the daemon's periodic tick.
     pub fn reap_prewarmed(&self) {
+        self.reap_prewarmed_with(&crate::config::Config::load());
+    }
+
+    fn reap_prewarmed_with(&self, config: &crate::config::Config) {
         let doomed: Vec<AgentId> = {
             let mut pool = self.prewarmed.lock().unwrap();
             let expired: Vec<_> = pool
                 .iter()
                 .filter(|(_, e)| {
-                    e.spawned_at.elapsed() > PREWARM_MAX_AGE
+                    !config.prewarm_agents
+                        || e.spawned_at.elapsed() > PREWARM_MAX_AGE
                         || !self.is_alive(&SessionRef::Agent(e.agent_id.clone()))
                 })
                 .map(|(k, _)| k.clone())
@@ -4726,6 +4735,60 @@ mod tests {
         );
         daemon.reap_prewarmed();
         assert!(daemon.prewarmed.lock().unwrap().is_empty());
+    }
+
+    /// Switching `prewarm_agents` off drains the pool on the next sweep. A
+    /// spare is a real CLI process the user can see — Claude's own
+    /// `/list-agents` lists it beside their sessions, named after the
+    /// directory (issue #15) — so the toggle has to take it away now, not
+    /// when it ages out.
+    #[tokio::test]
+    async fn reap_prewarmed_drains_the_pool_once_prewarming_is_off() {
+        let daemon = test_daemon();
+        let key = (WorktreeId("w1".into()), AgentKind::Claude);
+        let id = AgentId("warm-1".into());
+        let sref = SessionRef::Agent(id.clone());
+        let session = PtySession::spawn(
+            sref.clone(),
+            SpawnSpec {
+                program: "sleep".into(),
+                args: vec!["30".into()],
+                cwd: std::env::temp_dir(),
+                env: vec![],
+                scrub_env: &[],
+                cols: 80,
+                rows: 24,
+            },
+        )
+        .unwrap();
+        daemon.install_session(session);
+        daemon.prewarmed.lock().unwrap().insert(
+            key.clone(),
+            PrewarmEntry {
+                agent_id: id.clone(),
+                spawned_at: Instant::now(),
+                model: None,
+                effort: None,
+                buffered_hooks: Vec::new(),
+            },
+        );
+        let with_pool = |on: bool| crate::config::Config {
+            prewarm_agents: on,
+            ..crate::config::Config::default()
+        };
+
+        // Live, young and wanted: the ordinary sweep keeps it.
+        daemon.reap_prewarmed_with(&with_pool(true));
+        assert!(daemon.prewarmed.lock().unwrap().contains_key(&key));
+        assert!(daemon.is_alive(&sref), "a kept spare keeps its PTY");
+
+        // Off: the same sweep takes it, PTY and all.
+        daemon.reap_prewarmed_with(&with_pool(false));
+        assert!(daemon.prewarmed.lock().unwrap().is_empty());
+        assert!(
+            !daemon.is_alive(&sref),
+            "a drained spare's PTY goes with it"
+        );
     }
 
     #[test]

--- a/crates/nebula-tui/src/config.rs
+++ b/crates/nebula-tui/src/config.rs
@@ -196,6 +196,8 @@ pub enum SettingKind {
     CloseFinderOnOpen,
     SkipSessionNaming,
     SessionIdleTimeout,
+    PrewarmAgents,
+    PrewarmSessions,
     DoneSound,
     FeedbackSound,
     Theme,
@@ -266,6 +268,18 @@ pub const SETTINGS_TABS: &[SettingsTab] = &[
                 kind: SettingKind::SessionIdleTimeout,
                 label: "Idle session timeout",
                 hint: "Kill idle sessions in unviewed worktrees (busy ones spared; off disables)",
+                group: "",
+            },
+            SettingSpec {
+                kind: SettingKind::PrewarmAgents,
+                label: "Warm spare agent",
+                hint: "Boot a spare CLI in the selected worktree for instant creates (a peer in /list-agents)",
+                group: "",
+            },
+            SettingSpec {
+                kind: SettingKind::PrewarmSessions,
+                label: "Prewarm dead sessions",
+                hint: "Boot a worktree's dead sessions while the cursor rests on it, so attaching is instant",
                 group: "",
             },
             SettingSpec {
@@ -592,6 +606,18 @@ pub struct Config {
     /// disables. Owned by the daemon (which does the parsing and reaping);
     /// the TUI writes it so the settings overlay can cycle it.
     pub session_idle_timeout: String,
+    /// PREWARM POOL: keep one booted agent CLI standing by in the selected
+    /// worktree, so creating a session there adopts it instead of waiting
+    /// on a cold start. Owned by the daemon (which spawns, adopts and reaps
+    /// the spare); the TUI writes it so the settings overlay can toggle it.
+    /// A spare is a real CLI process — Claude's own `/list-agents` lists
+    /// it beside the sessions you made, named after the directory — and
+    /// switching this off drains the pool on the daemon's next sweep.
+    pub prewarm_agents: bool,
+    /// SESSION PREWARM: boot a worktree's dead sessions while the selection
+    /// rests on it, so attaching lands on a booted screen. Daemon-owned and
+    /// TUI-written, same as above.
+    pub prewarm_sessions: bool,
     /// What rings when a turn reaches FINISHED: "off", "bell" (terminal
     /// BEL) or the name of a macOS system sound (`Glass` by default,
     /// `Ping`, …; see [`SOUNDS`]). Resolved by [`Config::done_sound`],
@@ -693,6 +719,8 @@ impl Default for Config {
             close_finder_on_open: true,
             skip_session_naming: false,
             session_idle_timeout: "5m".into(),
+            prewarm_agents: true,
+            prewarm_sessions: true,
             done_sound: "Glass".into(),
             feedback_sound: "Sosumi".into(),
             theme: "default".into(),
@@ -763,9 +791,9 @@ impl Config {
 
     /// Put every setting back to its default and return the result. The
     /// file is rewritten from scratch rather than patched like
-    /// [`Config::save`], so keys the overlay doesn't own — the daemon's
-    /// `prewarm_*`, anything hand-added — go too: a reset reads as if the
-    /// file had never been edited.
+    /// [`Config::save`], so keys the overlay doesn't own — anything
+    /// hand-added — go too: a reset reads as if the file had never been
+    /// edited.
     pub fn reset_to_defaults() -> std::io::Result<Self> {
         #[cfg(test)]
         assert!(
@@ -807,6 +835,14 @@ impl Config {
         obj.insert(
             "session_idle_timeout".into(),
             serde_json::json!(self.session_idle_timeout),
+        );
+        obj.insert(
+            "prewarm_agents".into(),
+            serde_json::json!(self.prewarm_agents),
+        );
+        obj.insert(
+            "prewarm_sessions".into(),
+            serde_json::json!(self.prewarm_sessions),
         );
         obj.insert("done_sound".into(), serde_json::json!(self.done_sound));
         obj.insert(
@@ -968,6 +1004,8 @@ impl Config {
             SettingKind::CloseFinderOnOpen => on_off(self.close_finder_on_open).into(),
             SettingKind::SkipSessionNaming => on_off(self.skip_session_naming).into(),
             SettingKind::SessionIdleTimeout => self.session_idle_timeout.clone(),
+            SettingKind::PrewarmAgents => on_off(self.prewarm_agents).into(),
+            SettingKind::PrewarmSessions => on_off(self.prewarm_sessions).into(),
             SettingKind::DoneSound => self.done_sound.clone(),
             SettingKind::FeedbackSound => self.feedback_sound.clone(),
             SettingKind::Theme => self.theme.clone(),
@@ -1026,6 +1064,12 @@ impl Config {
             SettingKind::SessionIdleTimeout => {
                 self.session_idle_timeout =
                     cycle_choice(&self.session_idle_timeout, SESSION_IDLE_TIMEOUTS, step).into();
+            }
+            SettingKind::PrewarmAgents => {
+                self.prewarm_agents = !self.prewarm_agents;
+            }
+            SettingKind::PrewarmSessions => {
+                self.prewarm_sessions = !self.prewarm_sessions;
             }
             SettingKind::DoneSound => {
                 self.done_sound = cycle_choice(&self.done_sound, SOUNDS, step).into();
@@ -1272,6 +1316,41 @@ mod tests {
         assert!(!load_from(&path).close_finder_on_open);
     }
 
+    /// The two prewarm keys are daemon-owned but overlay-toggled, like
+    /// `git_init_on_create`: on by default, a missing key reads as on, and
+    /// the Sessions-tab rows round-trip through the saved file.
+    #[test]
+    fn prewarm_toggles_default_on_and_round_trip() {
+        let cfg = Config::default();
+        assert!(cfg.prewarm_agents && cfg.prewarm_sessions);
+        let cfg: Config = serde_json::from_str("{}").unwrap();
+        assert!(cfg.prewarm_agents && cfg.prewarm_sessions);
+        let cfg: Config =
+            serde_json::from_str(r#"{"prewarm_agents": false, "prewarm_sessions": false}"#)
+                .unwrap();
+        assert!(!cfg.prewarm_agents && !cfg.prewarm_sessions);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut cfg = Config::default();
+        let (t, r) = locate(SettingKind::PrewarmAgents).unwrap();
+        assert_eq!(SETTINGS_TABS[t].title, "Sessions");
+        cfg.cycle(t, r, 0);
+        let (t, r) = locate(SettingKind::PrewarmSessions).unwrap();
+        assert_eq!(SETTINGS_TABS[t].title, "Sessions");
+        cfg.cycle(t, r, 0);
+        assert_eq!(cfg.value_label(SettingKind::PrewarmAgents), "off");
+        assert_eq!(cfg.value_label(SettingKind::PrewarmSessions), "off");
+        cfg.save_to(&path).unwrap();
+        let saved: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        // Written under the daemon's own key names, since it is the reader.
+        assert_eq!(saved["prewarm_agents"], false);
+        assert_eq!(saved["prewarm_sessions"], false);
+        let loaded = load_from(&path);
+        assert!(!loaded.prewarm_agents && !loaded.prewarm_sessions);
+    }
+
     #[test]
     fn defaults_enter_attaches() {
         assert!(Config::default().palette_enter_attaches);
@@ -1296,12 +1375,12 @@ mod tests {
             // A key the overlay doesn't own survives an ordinary save…
             let mut root: serde_json::Value =
                 serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-            root["prewarm_agents"] = serde_json::json!(false);
+            root["hand_added_key"] = serde_json::json!(false);
             std::fs::write(&path, serde_json::to_vec_pretty(&root).unwrap()).unwrap();
             Config::load().save().unwrap();
             let raw = std::fs::read_to_string(&path).unwrap();
             assert!(
-                raw.contains("prewarm_agents"),
+                raw.contains("hand_added_key"),
                 "save() patches, keeping foreign keys:\n{raw}"
             );
 
@@ -1311,7 +1390,7 @@ mod tests {
             assert!(reset.keybindings.is_empty());
             let raw = std::fs::read_to_string(&path).unwrap();
             assert!(
-                !raw.contains("prewarm_agents"),
+                !raw.contains("hand_added_key"),
                 "foreign key survived:\n{raw}"
             );
             let loaded = Config::load();

--- a/crates/nebula-tui/src/event_loop.rs
+++ b/crates/nebula-tui/src/event_loop.rs
@@ -16984,7 +16984,7 @@ diff --git a/src/b.rs b/src/b.rs
             cfg.save().unwrap();
             let mut root: serde_json::Value =
                 serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
-            root["prewarm_agents"] = serde_json::json!(false);
+            root["hand_added_key"] = serde_json::json!(false);
             std::fs::write(&path, serde_json::to_vec_pretty(&root).unwrap()).unwrap();
 
             let mut app = App::new();
@@ -17014,7 +17014,7 @@ diff --git a/src/b.rs b/src/b.rs
             assert!(saved.show_workspaces);
             assert!(saved.keybindings.is_empty());
             let raw = std::fs::read_to_string(&path).unwrap();
-            assert!(!raw.contains("prewarm_agents"), "{raw}");
+            assert!(!raw.contains("hand_added_key"), "{raw}");
         });
     }
 

--- a/crates/nebula-tui/src/git_diff.rs
+++ b/crates/nebula-tui/src/git_diff.rs
@@ -72,10 +72,26 @@ pub fn classify_diff_line(line: &str) -> DiffLineKind {
     }
 }
 
+/// `git -C root`, with the locks git takes on its own initiative switched
+/// off. `git status` and `git diff` refresh the index's stat cache as a
+/// side effect and, when it is stale — it always is while an agent edits
+/// files — write it back through `.git/index.lock`. The WORKTREES PANEL's
+/// changed-files badge polls `status` every two seconds on the checkout
+/// the user is working in, so left on, that write lands under the agent's
+/// own `git add` / `commit` / `checkout`, which then fails with "Unable to
+/// create '.git/index.lock': File exists" (issue #15). Nothing the TUI
+/// runs needs the refresh persisted — the agent CLIs themselves run their
+/// background git with `--no-optional-locks` for the same reason — and
+/// commands that must lock (none of ours) still do: `GIT_OPTIONAL_LOCKS=0`
+/// only skips the optional ones. Every TUI-side git goes through here.
+pub(crate) fn git_command(root: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C").arg(root).env("GIT_OPTIONAL_LOCKS", "0");
+    cmd
+}
+
 pub(crate) fn run_git(root: &Path, args: &[&str]) -> Result<Output, String> {
-    Command::new("git")
-        .arg("-C")
-        .arg(root)
+    git_command(root)
         .args(args)
         .output()
         .map_err(|e| format!("failed to run git: {e}"))
@@ -404,6 +420,61 @@ mod tests {
         assert!(files[0].is_untracked());
         let diff = diff_for(&repo, &files[0], false);
         assert!(diff.contains("+content"), "{diff}");
+    }
+
+    /// The WORKTREES PANEL badge polls `changed_files` every two seconds on
+    /// the checkout the user's agent is working in. A plain `git status`
+    /// rewrites the index through `.git/index.lock` whenever its stat cache
+    /// is stale, and an agent mid-`git add` or `commit` then fails with
+    /// "index.lock: File exists" (issue #15). The poll must read without
+    /// ever writing.
+    #[test]
+    fn changed_files_never_rewrites_the_index() {
+        use std::os::unix::fs::MetadataExt;
+        use std::time::{Duration, UNIX_EPOCH};
+        let dir = tempfile::tempdir().unwrap();
+        let repo = make_repo(&dir);
+        let index = repo.join(".git").join("index");
+        // A rewrite lands as a rename over the file, so the inode moves;
+        // the mtime is the second witness in case a filesystem reuses it.
+        let stamp = || {
+            let meta = std::fs::metadata(&index).unwrap();
+            (meta.ino(), meta.modified().unwrap())
+        };
+        // Same content, a different (whole-second) mtime: the index's
+        // stat cache no longer matches, which is exactly what makes a
+        // status want to write the refreshed cache back.
+        let stale = |secs: u64| {
+            let file = std::fs::File::options()
+                .write(true)
+                .open(repo.join("tracked.txt"))
+                .unwrap();
+            file.set_modified(UNIX_EPOCH + Duration::from_secs(secs))
+                .unwrap();
+        };
+
+        stale(1_000_000_000);
+        let before = stamp();
+        changed_files(&repo).unwrap();
+        assert_eq!(stamp(), before, "the status poll rewrote the index");
+
+        // The control: with optional locks allowed, the same status does
+        // rewrite it — so the assertion above is testing something.
+        stale(1_000_000_100);
+        let before = stamp();
+        let plain = Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .env("GIT_OPTIONAL_LOCKS", "1")
+            .args(["status", "--porcelain=v1", "-z", "-uall"])
+            .output()
+            .unwrap();
+        assert!(plain.status.success());
+        assert_ne!(
+            stamp(),
+            before,
+            "a plain status left the index alone, so this test proves nothing"
+        );
     }
 
     #[test]

--- a/crates/nebula-tui/src/remote.rs
+++ b/crates/nebula-tui/src/remote.rs
@@ -18,7 +18,6 @@
 //!   remotes with no web page at all. Those are a flash, not a bad URL.
 
 use std::path::Path;
-use std::process::Command;
 
 /// The web page for the repository checked out at `root`. `Err` is a
 /// user-facing flash message.
@@ -52,9 +51,7 @@ fn remote_url(root: &Path, name: &str) -> Option<String> {
 /// `git -C root <args>`, stdout on success. A failing git (no remote by
 /// that name, not a repo) is `Err` carrying its own complaint.
 fn run_git(root: &Path, args: &[&str]) -> Result<String, String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(root)
+    let out = crate::git_diff::git_command(root)
         .args(args)
         .output()
         .map_err(|e| format!("failed to run git: {e}"))?;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,24 +62,30 @@ tree is worked; every row there is off by default.
 | `pi_model` | string | `"default"` | Agents | Default `--model` for new Pi sessions. Pi takes a fuzzy pattern across every provider it has credentials for, so the overlay lists families (`opus`, `sonnet`, `haiku`, `gpt-5.5`); a hand-edited `provider/id` such as `anthropic/claude-sonnet-5` passes through verbatim. |
 | `pi_effort` | string | `"default"` | Agents | Default `--thinking` level for new Pi sessions: `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, or the `"default"` sentinel. |
 | `keybindings` | object | `{}` | Hotkeys | KEYMAP overrides, keyed by action id, valued with a comma-separated chord list: `{"git_diff": "ctrl+g, g"}`. An empty string deliberately unbinds; unknown ids are ignored. Only rows that differ from the defaults are written. |
-| `prewarm_agents` | bool | `true` | — | PREWARM POOL: pre-spawn an agent CLI while you are still naming the session, so creation feels instant. **Costs one idle CLI process per warm slot** (150–300 MB each, up to 15 minutes). `false` opts out. |
-| `prewarm_sessions` | bool | `true` | — | SESSION PREWARM: pre-spawn a WORKTREE's dead sessions when your selection rests on it, so attaching shows an already-booted screen instead of a booting shell. **Costs idle shell/CLI processes for sessions you may never open.** `false` opts out. |
+| `prewarm_agents` | bool | `true` | Sessions | DAEMON-owned PREWARM POOL: keep one booted agent CLI standing by in the selected WORKTREE, so creating a session there adopts it and feels instant. **Costs one idle CLI process per warm slot** (150–300 MB each, up to 15 minutes), and that spare is a real session as far as the CLI is concerned — Claude's own `/list-agents` lists it beside the sessions you made, named after the directory (`my-repo-3f`), and the memory modal (`Shift+M`) groups it under **warm spares**. Off drains the pool on the DAEMON's next sweep (within 30 s). |
+| `prewarm_sessions` | bool | `true` | Sessions | DAEMON-owned SESSION PREWARM: boot a WORKTREE's dead sessions when your selection rests on it, so attaching shows an already-booted screen instead of a booting shell. **Costs idle shell/CLI processes for sessions you may never open.** Off stops booting them; sessions already up stay until the IDLE REAPER takes them. |
 
 `hide_projects` and `hide_worktrees` default to `false`. Set either to `true` to start with that panel
 hidden; the SESSIONS PANEL always remains visible.
 
-### Prewarming is hand-edit-only
+### Prewarming
 
-`prewarm_agents` and `prewarm_sessions` have no SETTINGS OVERLAY row at all — the only way to turn
-prewarming off is to write the key into CONFIG.JSON yourself:
+`prewarm_agents` and `prewarm_sessions` are the two settings that cost real processes you never
+asked for, so they are worth knowing about on a laptop or a small remote box — and worth knowing
+about if your sessions talk to each other. A warm spare is a bare `claude` sitting at its prompt in
+the selected worktree: Claude's `/list-agents` shows it as a peer named after the directory, the
+same way it names any session you have not titled yet, so a spare beside a fresh untitled session
+reads as two copies of one session (`my-repo-3f`, `my-repo-a1`), one of them forever idle. That is
+the spare, not a duplicate — `Shift+M` lists it under **warm spares** with its PID. Both rows live on
+the SETTINGS OVERLAY's Sessions tab (`Warm spare agent`, `Prewarm dead sessions`); the same keys in
+CONFIG.JSON work by hand:
 
 ```json
 { "prewarm_agents": false, "prewarm_sessions": false }
 ```
 
-They are the two settings that cost real processes you never asked for, so they are worth knowing
-about on a laptop or a small remote box. `session_idle_timeout` is what bounds their cost when they
-are left on.
+Turning the pool off takes the standing spares away on the DAEMON's next sweep. `session_idle_timeout`
+is what bounds the cost of both when they are left on.
 
 ### What `session_idle_timeout` accepts
 
@@ -98,7 +104,8 @@ on the next ATTACH or prewarm, and an agent RESUMES its conversation there.
   same file: color theme, animations, whether the Workspaces bar, PROJECTS PANEL,
   and WORKTREES PANEL are shown,
   editor, which agent CLIs the new-session menu offers (at least one stays on) and their default model
-  and reasoning effort, the idle timeout, the done sound (`done_sound`: a ding
+  and reasoning effort, the idle timeout, whether a warm spare and a worktree's dead sessions are
+  pre-booted (`prewarm_agents`, `prewarm_sessions`), the done sound (`done_sound`: a ding
   when a turn finishes — a macOS system sound such as `Glass`, the default; `bell` for the terminal
   bell, which Ghostty keeps silent unless its `bell-features` include `audio`; or `off`. Over
   `nebula ssh` and off macOS it is always the bell), the feedback sound (`feedback_sound`: the same

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -145,10 +145,12 @@
   no client is watching are killed after `session_idle_timeout` (5m by default) — working agents, ones
   waiting on you, and terminals with a command running are all spared, and a reaped agent
   revives on the next attach with its conversation resumed. Both halves of the PREWARM POOL are
-  switchable — `prewarm_agents` and `prewarm_sessions` in CONFIG.JSON, `true` by default and
-  hand-edit-only, since neither has a SETTINGS OVERLAY row (see [Configuration](configuration.md)) —
-  and a warm spare nobody claims inside 15 min is reaped on its own, because it holds real memory and
-  its context goes stale. The IDLE REAPER's check is a 15 s sweep (`NEBULA_IDLE_REAP_MS`), so the real
+  switchable — `prewarm_agents` and `prewarm_sessions`, `true` by default, on the SETTINGS OVERLAY's
+  Sessions tab or by hand in CONFIG.JSON (see [Configuration](configuration.md)); switching the pool
+  off drains its spares on the next sweep — and a warm spare nobody claims inside 15 min is reaped on
+  its own, because it holds real memory and its context goes stale. A spare is a bare CLI at its
+  prompt, so the CLI's own session list (Claude's `/list-agents`) shows it beside your sessions,
+  named after the directory. The IDLE REAPER's check is a 15 s sweep (`NEBULA_IDLE_REAP_MS`), so the real
   latency is the timeout plus up to 15 s more; `session_idle_timeout` also takes `"off"`, which
   switches reaping off entirely.
 

--- a/scripts/shot/scenes/memory-warm-spares.keys
+++ b/scripts/shot/scenes/memory-warm-spares.keys
@@ -1,0 +1,2 @@
+# The memory modal: the PREWARM POOL's spares grouped under "warm spares", apart from real sessions.
+M

--- a/scripts/shot/scenes/settings-sessions-prewarm.keys
+++ b/scripts/shot/scenes/settings-sessions-prewarm.keys
@@ -1,0 +1,6 @@
+# Settings on the Sessions tab, cursor on the new Warm spare agent row so its hint shows in the footer.
+s
+Tab
+j
+j
+j


### PR DESCRIPTION
Closes #15. The `.git/index.lock: File exists` failures an agent hit were nebula's own doing — the WORKTREES PANEL's two-second `git status` poll was rewriting the index under the agent's `git add` — and the "duplicate" `claude` processes were the PREWARM POOL's warm spares, which now have SETTINGS OVERLAY rows and go away when switched off.

**Contents:** [🐛 Symptom](#user-content-symptom) · [🔍 Cause](#user-content-cause) · [✅ Fix](#user-content-fix) · [📸 Screenshots](#user-content-screenshots) · [🔁 Flow](#user-content-flow) · [⚠️ Risk](#user-content-risk) · [🔧 Technical overview](#user-content-technical-overview) · [🧪 Proof](#user-content-proof) · [📝 Notes](#user-content-notes)

## 🐛 Symptom <a id="symptom"></a>

"Duplicate Sessions Created" (#15, thanks @LRam10): after creating a worktree and launching a session, Claude's `/list-agents` showed two entries with the same name (`<name>-[xxx]`), one of them always idle, so sessions that message each other picked the wrong one. Alongside it, the working session kept failing git commands with `Unable to create '.git/index.lock': File exists`, which the reporter pinned on the second process.

## 🔍 Cause <a id="cause"></a>

Two separate things, neither a duplicate session.

- **The lock was nebula's.** The changed-files badge on the WORKTREES PANEL runs `git status --porcelain` every two seconds on the selected checkout — the one the agent is editing in. A plain `git status` refreshes the index's stat cache and, whenever that cache is stale (constantly, while files are being written), writes the index back through `.git/index.lock`. An agent's `git add`, `commit` or `checkout` landing in that window fails with exactly the reported error. Claude Code itself runs its background `git status` and `git log` with `--no-optional-locks` for this reason; nebula's poll did not.
- **The twins are warm spares.** The PREWARM POOL keeps one bare `claude` booted in the selected worktree so the next create is instant. Claude's `/list-agents` names any untitled session after its directory (`my-repo-3f`), so a spare beside a fresh session in the same worktree reads as two copies of one session — one forever idle, since nobody ever types into it. Both PIDs in the reporter's screenshots are in the memory modal; `79013` sits under **warm spares**. The two pool keys were documented as hand-edit-only, which the issue thread offered to change.

Ruled out along the way, so the reviewer need not re-check: claude exits promptly on the SIGHUP the DAEMON sends (exit 129 within a second), so no process outlives a kill or a `nebula kill`; and a booting spare's git is all read-only — it never touches `index.lock`.

## ✅ Fix <a id="fix"></a>

- **The TUI's git never takes optional locks.** Every git the TUI spawns — the status poll, the diff viewer, find-in-files, the remote lookup — goes through one constructor that sets `GIT_OPTIONAL_LOCKS=0`.
  - `git status` and `git diff` still read the working tree; they just stop persisting the refreshed stat cache.
  - Commands that must lock (none of the TUI's) are unaffected: the variable skips only the optional ones.
  - The DAEMON's git is untouched — `worktree add/remove/list` and `rev-parse` take no optional lock.
- **Warm spares are a Settings row.** `Settings › Sessions › Warm spare agent` and `Settings › Sessions › Prewarm dead sessions` toggle `prewarm_agents` and `prewarm_sessions`, the same daemon-owned keys the file always took.
  - Switching the pool off drains the standing spares on the DAEMON's next sweep (within 30 s) instead of leaving them to age out over 15 minutes.
  - The hint on the row says what a spare looks like from `/list-agents`; the docs' new **Prewarming** section says the same at length.
- **Unchanged.** The pool itself, its adoption on create, the 15-minute reap, and the `Shift+M` memory modal's **warm spares** group are as before; so is every git the DAEMON runs.

## 📸 Screenshots <a id="screenshots"></a>

| Settings › Sessions with the two new rows | `Shift+M`: where the "duplicates" live |
|---|---|
| ![The Sessions tab of the settings overlay, cursor on the new Warm spare agent row, its hint in the footer](https://raw.githubusercontent.com/AgentSystemLabs/nebula/pr-assets/issue-15-duplicate-sessions/settings-sessions-prewarm.png) | ![The memory modal grouping the pool's one spare under warm spares, apart from real sessions](https://raw.githubusercontent.com/AgentSystemLabs/nebula/pr-assets/issue-15-duplicate-sessions/memory-warm-spares.png) |

The lock bug has no nebula screen to photograph — it is git's error inside the agent's terminal — so its before/after is the measurement. A background loop ran the TUI's exact poll (`git status --porcelain=v1 -z -uall`) against a foreground loop of `git add` for eight seconds each, on git 2.50:

```
TUI-style plain status poll        : git add ok=610 failed=41
status poll with optional locks off: git add ok=659 failed=0

fatal: Unable to create '…/.git/index.lock': File exists.
```

## 🔁 Flow <a id="flow"></a>

```mermaid
flowchart LR
  subgraph tui["TUI"]
    poll["GIT POLL · every 2 s<br/>git status --porcelain"]
  end
  subgraph repo[".git of the selected worktree"]
    lock["index.lock"]
    idx["index"]
  end
  subgraph agent["agent CLI, same worktree"]
    add["git add / commit / checkout"]
  end
  poll -- "before: stale stat cache → rewrite" --> lock
  lock -. "rename over" .-> idx
  add -- "needs the same lock" --> lock
  lock -- "File exists" --> add
  poll -- "after: GIT_OPTIONAL_LOCKS=0 → read only" --> idx
  linkStyle 0 stroke:#d33,stroke-width:2px
  linkStyle 3 stroke:#d33,stroke-width:2px
  linkStyle 4 stroke:#2a2,stroke-width:2px
```

## ⚠️ Risk <a id="risk"></a>

**Verdict:** 🟢 Low risk — one environment variable on read-only git the TUI already spawned, two overlay rows over keys the DAEMON already read, and a drain that reuses the pool's existing kill path.

| | Level | Why |
|---|---|---|
| 🔒 **Security & production** | Low | No new surface: no `ClientRequest`, no hook route, no new shell call. `GIT_OPTIONAL_LOCKS=0` only removes a write the TUI never needed. The drain kills only pool entries — sessions with a row are untouched — and only once the user has switched the pool off. |
| ⚡ **Performance** | Low | Off every hot path. The poll runs the same command with one env var; skipping the index write makes it cheaper, not dearer (a later `git diff` in the agent's shell re-stats what the poll would have cached). The drain rides the existing 30 s status tick. |
| 🧩 **Fit with the codebase** | Low | The rows follow `git_init_on_create` / `session_idle_timeout` exactly — daemon-owned key, TUI-written, on the tab where the idle timeout lives. `git_command` is the `run_git` helper the three call sites already shared, with one env var added. |

**Rollback:** `git revert` of the merge undoes all of it. A `config.json` written meanwhile keeps `prewarm_agents` / `prewarm_sessions` keys, which the DAEMON read before this PR too, so nothing is orphaned; no PROTOCOL VERSION bump, no store migration.

## 🔧 Technical overview <a id="technical-overview"></a>

- **The line that mattered.** `crates/nebula-tui/src/git_diff.rs` — `run_git` built `Command::new("git").arg("-C").arg(root)` and ran `status`, `diff`, `ls-files`, `rev-parse` through it; `git_command` now builds that same command with `GIT_OPTIONAL_LOCKS=0`, and `run_git` (also `grep_search`'s caller) and `remote.rs`'s own `run_git` go through it.
- **Why it was missed.** `git status` writes the index only when the stat cache is stale, and the tests' repos are never stale between a commit and a status; a working agent's checkout always is. The reporter's pids pointed at the spare, which was in the same directory and looked like the culprit.
- **Why the env var, not `--no-optional-locks`.** Same mechanism in git (2.15+); the variable rides one constructor instead of every argv, so a future call site cannot forget it.
- **The pool drain.** `crates/nebula-daemon/src/registry.rs` — `reap_prewarmed` now takes the loaded `Config` (`reap_prewarmed_with`) and dooms every entry when `prewarm_agents` is off, on top of the age and liveness rules; the TUI keeps sending `PrewarmAgent`, which the DAEMON already declined when off.
- **The rows.** `crates/nebula-tui/src/config.rs` — `SettingKind::PrewarmAgents` / `PrewarmSessions`, two Sessions-tab specs, the fields, defaults, `write_into`, `value_label`, `cycle`. The reset tests used `prewarm_agents` as their example of a key the overlay does not own; they use a made-up one now.
- **Why not name the spares.** `claude --name "warm spare"` would make them distinguishable in `/list-agents`, but CLAUDE TITLE SYNC adopts any name Claude holds that nebula has not seen as a user rename, so an adopted spare would come up titled "warm spare" with AUTO-TITLE retired. A follow-up if it matters.

## 🧪 Proof <a id="proof"></a>

- **Regression test.** `changed_files_never_rewrites_the_index` in `crates/nebula-tui/src/git_diff.rs` — stales the index, polls, and checks the index file's inode and mtime did not move; a control shows a plain status does move them. Fails on `origin/main`, passes here.
- **Drain.** `reap_prewarmed_drains_the_pool_once_prewarming_is_off` in `crates/nebula-daemon/src/registry.rs` — a live spare survives the sweep with the pool on and goes, PTY and all, with it off.
- **Rows.** `prewarm_toggles_default_on_and_round_trip` in `crates/nebula-tui/src/config.rs` — defaults on, missing keys read as on, both rows locate on Sessions and round-trip through the saved file under the daemon's key names.
- **Gate.** `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean; `cargo test --workspace` green — 885 tests across 10 targets, `e2e_pty` included.

## 📝 Notes <a id="notes"></a>

- Branches cleanly off `main` at v0.23.0; three commits (fix, rows + drain + docs, screenshot scenes), no conflicts.
- Two SCREENSHOT HARNESS scenes come with it (`settings-sessions-prewarm`, `memory-warm-spares`); the PNGs live on `pr-assets`.
- For the issue thread: the reporter's `79013` is listed under **warm spares** in their own `Shift+M` screenshot, and untitled Claude sessions are named `<directory>-<xx>`, which is why two in one worktree look alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFJFWzHThp9CGwNrxLc6LK
