### PR TITLE
Every pane is the same truecolor terminal: a stray NO_COLOR no longer paints Claude Code white

### DIFF
--- a/crates/nebula-core/src/env.rs
+++ b/crates/nebula-core/src/env.rs
@@ -40,6 +40,24 @@ pub const UPDATE_CHECK_SECS: &str = "NEBULA_UPDATE_CHECK_SECS";
 /// every agent PTY and must never leak into plain terminals.
 pub const AGENT_SESSION_VARS: &[&str] = &[AGENT_ID, API_URL, API_TOKEN];
 
+/// `TERM` every PTY child is given. The pane is nebula's own grid — a vt100
+/// parser the TUI repaints through ratatui — and that grid keeps 24-bit
+/// colour whatever terminal nebula itself runs in, so the child never
+/// hears the host's `TERM` (`foot`, `xterm-ghostty`, `tmux-256color`).
+pub const PANE_TERM: &str = "xterm-256color";
+/// `COLORTERM` for the same grid: every `38;2;r;g;b` the child sends is
+/// kept, so chalk-style detection may pick truecolor over the 256-colour
+/// downsample `TERM` alone allows.
+pub const PANE_COLORTERM: &str = "truecolor";
+/// Colour overrides scrubbed from every PTY child. A `NO_COLOR` or a
+/// `FORCE_COLOR=0` describes the shell the daemon happened to be started
+/// from — an agent's tool shell, a CI job — or a login-only profile, not
+/// the pane; Claude Code reads either as "no colour at all" and paints its
+/// whole UI in the default foreground while the TUI around it stays
+/// coloured (#37). The TUI still honours its own `NO_COLOR` on the way
+/// out, so a user who wants none keeps none.
+pub const PANE_COLOR_OVERRIDES: &[&str] = &["NO_COLOR", "FORCE_COLOR"];
+
 /// The value of `var`, treating unset and empty the same way — an empty
 /// override is how a caller says "use the default".
 pub fn non_empty(var: &str) -> Option<String> {

--- a/crates/nebula-daemon/src/pty/mod.rs
+++ b/crates/nebula-daemon/src/pty/mod.rs
@@ -143,7 +143,15 @@ impl PtySession {
         let mut cmd = CommandBuilder::new(&spec.program);
         cmd.args(&spec.args);
         cmd.cwd(&spec.cwd);
-        cmd.env("TERM", "xterm-256color");
+        // The child paints nebula's grid, not the terminal the daemon was
+        // started from: name that grid and drop the colour overrides the
+        // daemon inherited. Agent launches restate all three after the
+        // login shell's profile too (`login_shell_wrap`).
+        cmd.env("TERM", nebula_core::env::PANE_TERM);
+        cmd.env("COLORTERM", nebula_core::env::PANE_COLORTERM);
+        for name in nebula_core::env::PANE_COLOR_OVERRIDES {
+            cmd.env_remove(name);
+        }
         for name in spec.scrub_env {
             cmd.env_remove(name);
         }
@@ -488,5 +496,64 @@ mod tests {
         assert_eq!(title, "✳ Fix Login");
         assert_eq!(session.window_title().as_deref(), Some("✳ Fix Login"));
         session.kill();
+    }
+
+    /// The pane is nebula's grid, not the terminal the daemon was started
+    /// from: every child hears `TERM`/`COLORTERM` for that grid, and a
+    /// `NO_COLOR` or `FORCE_COLOR` the daemon inherited never reaches it.
+    #[tokio::test]
+    async fn child_is_told_the_pane_is_a_truecolor_terminal() {
+        // The daemon's own environment is the base the child is built from,
+        // so the overrides have to sit there for the scrub to be exercised.
+        // Only this test sets them, and only until the spawn has read them;
+        // whatever was there before is put back.
+        let before: Vec<(&str, Option<std::ffi::OsString>)> = ["NO_COLOR", "FORCE_COLOR", "TERM"]
+            .into_iter()
+            .map(|name| (name, std::env::var_os(name)))
+            .collect();
+        std::env::set_var("NO_COLOR", "1");
+        std::env::set_var("FORCE_COLOR", "0");
+        std::env::set_var("TERM", "foot");
+        let session = PtySession::spawn(
+            SessionRef::Agent(AgentId::generate()),
+            SpawnSpec {
+                program: "/bin/sh".into(),
+                args: vec![
+                    "-c".into(),
+                    r#"printf 'env=%s|%s|%s|%s' "$TERM" "$COLORTERM" "${NO_COLOR-unset}" "${FORCE_COLOR-unset}""#
+                        .into(),
+                ],
+                cwd: std::env::temp_dir(),
+                env: vec![],
+                scrub_env: &[],
+                cols: DEFAULT_COLS,
+                rows: DEFAULT_ROWS,
+            },
+        )
+        .unwrap();
+        for (name, value) in before {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
+        let mut rx = session.events.subscribe();
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            loop {
+                match rx.recv().await {
+                    Ok(PtyEvent::Exited { .. }) => break,
+                    Ok(_) => continue,
+                    Err(e) => panic!("event stream ended: {e}"),
+                }
+            }
+        })
+        .await
+        .expect("child exits within 10s");
+        let (_, bytes) = session.snapshot(None);
+        let out = String::from_utf8_lossy(&bytes);
+        assert!(
+            out.contains("env=xterm-256color|truecolor|unset|unset"),
+            "child saw: {out:?}"
+        );
     }
 }

--- a/crates/nebula-daemon/src/registry.rs
+++ b/crates/nebula-daemon/src/registry.rs
@@ -3142,11 +3142,29 @@ fn cli_missing_message(kind: AgentKind) -> String {
 }
 
 /// Wrap `program args…` in a login + interactive shell (`$SHELL -l -i -c
-/// 'exec …'`) so the child gets the user's real environment — ~/.zprofile
-/// and ~/.zshrc on zsh — rather than the daemon's. `exec` keeps the child
-/// as the PTY's direct process (exit codes and signals pass through).
+/// 'exec env … prog args'`) so the child gets the user's real environment —
+/// ~/.zprofile and ~/.zshrc on zsh — rather than the daemon's. `exec` keeps
+/// the child as the PTY's direct process (exit codes and signals pass
+/// through); `env` execs straight into it, so nothing sits in between.
+///
+/// The `env` restates what the pane is *after* those files have run: `TERM`
+/// and `COLORTERM` name nebula's own grid — 24-bit colour whatever the host
+/// terminal — and `NO_COLOR` / `FORCE_COLOR` are dropped. A login-only
+/// profile that exports `NO_COLOR` reaches a session here and nowhere else
+/// (foot and Ghostty on Linux start non-login shells), and Claude Code takes
+/// it as "no colour": its whole UI in the default foreground while the TUI
+/// around it stays coloured (#37). The spawn sets the same three against the
+/// daemon's inherited environment; this covers the profile's.
 fn login_shell_wrap(shell: &str, program: &str, args: &[String]) -> (String, Vec<String>) {
-    let mut cmdline = String::from("exec");
+    let mut cmdline = String::from("exec env");
+    for name in env::PANE_COLOR_OVERRIDES {
+        cmdline.push_str(" -u ");
+        cmdline.push_str(name);
+    }
+    cmdline.push_str(" TERM=");
+    cmdline.push_str(env::PANE_TERM);
+    cmdline.push_str(" COLORTERM=");
+    cmdline.push_str(env::PANE_COLORTERM);
     for part in std::iter::once(program).chain(args.iter().map(String::as_str)) {
         cmdline.push_str(" '");
         cmdline.push_str(&part.replace('\'', "'\\''"));
@@ -3703,6 +3721,10 @@ mod tests {
         assert!(err.contains("message"), "{err}");
     }
 
+    /// What every agent launch execs once the login shell's files have run.
+    const PANE_ENV: &str =
+        "exec env -u NO_COLOR -u FORCE_COLOR TERM=xterm-256color COLORTERM=truecolor";
+
     #[test]
     fn login_shell_wrap_quotes_and_execs() {
         let (program, args) = login_shell_wrap(
@@ -3713,11 +3735,47 @@ mod tests {
         assert_eq!(program, "/bin/zsh");
         assert_eq!(
             args,
-            vec!["-l", "-i", "-c", "exec 'claude' '--resume' 'sid-1'"]
+            vec![
+                "-l",
+                "-i",
+                "-c",
+                &format!("{PANE_ENV} 'claude' '--resume' 'sid-1'")
+            ]
         );
         // Single quotes in an arg survive the wrapping.
         let (_, args) = login_shell_wrap("/bin/zsh", "echo", &["it's".to_string()]);
-        assert_eq!(args[3], r"exec 'echo' 'it'\''s'");
+        assert_eq!(args[3], format!(r"{PANE_ENV} 'echo' 'it'\''s'"));
+    }
+
+    /// The command line's `env` really does undo a profile's colour
+    /// overrides and restate the pane: run it through a plain `sh -c` with
+    /// `NO_COLOR` and a foreign `TERM` already exported, as a `.profile`
+    /// would leave them, and read back what the program sees.
+    #[test]
+    fn login_shell_wrap_restates_the_pane_after_the_profile() {
+        let (_, args) = login_shell_wrap(
+            "/bin/sh",
+            "sh",
+            &[
+                "-c".to_string(),
+                r#"printf '%s|%s|%s|%s' "$TERM" "$COLORTERM" "${NO_COLOR-unset}" "${FORCE_COLOR-unset}""#
+                    .to_string(),
+            ],
+        );
+        let out = std::process::Command::new("/bin/sh")
+            .arg("-c")
+            .arg(&args[3])
+            .env("NO_COLOR", "1")
+            .env("FORCE_COLOR", "0")
+            .env("TERM", "foot")
+            .output()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout),
+            "xterm-256color|truecolor|unset|unset",
+            "stderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
 
     fn test_daemon() -> Arc<Daemon> {

--- a/crates/nebula-tui/src/vim_term.rs
+++ b/crates/nebula-tui/src/vim_term.rs
@@ -93,7 +93,10 @@ impl VimTerm {
         let mut cmd = CommandBuilder::new(program);
         cmd.args(args);
         cmd.cwd(cwd);
-        cmd.env("TERM", "xterm-256color");
+        // The modal is drawn on nebula's grid, the same truecolor terminal
+        // every session pane is (see `nebula_core::env::PANE_TERM`).
+        cmd.env("TERM", nebula_core::env::PANE_TERM);
+        cmd.env("COLORTERM", nebula_core::env::PANE_COLORTERM);
 
         let mut child = pair
             .slave

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,6 +8,14 @@
   with scrollback replayed. When the daemon swaps the process under a session you are looking at — a
   restart, or the `nebula worktree` relocation at the end of a turn — the pane is rebound to the new
   one on its own.
+- **Every pane is the same truecolor terminal.** A session paints nebula's own grid, not the terminal
+  nebula runs in, so the daemon tells each child `TERM=xterm-256color` and `COLORTERM=truecolor` and
+  drops any `NO_COLOR` / `FORCE_COLOR` it inherited. An agent launch runs through your login shell
+  (`$SHELL -l -i -c 'exec env … claude …'`) so it sees your real PATH, and restates all three after your
+  profile has run. Claude Code takes a stray `NO_COLOR` — exported by the agent shell the daemon was
+  first started from, or by a login-only profile no interactive terminal sources — as "no colour" and
+  paints its whole UI in the default foreground while the TUI around it stays coloured; the TUI still
+  honours its own `NO_COLOR` on the way out, so a user who wants none keeps none.
 - **Client and DAEMON must agree on the PROTOCOL VERSION.** IPC frames are positional msgpack, so any
   change to the shared types bumps `PROTOCOL_VERSION` (`crates/nebula-core/src/protocol.rs`) and the
   handshake refuses a mismatched pair — the DAEMON answers `Incompatible`, the TUI bails, and the


### PR DESCRIPTION
Closes #37. A Claude Code session opened in the TERMINAL PANE on Linux came up with every character in the default foreground; the pane is now told, twice, that it is nebula's own truecolor terminal, and a `NO_COLOR` the DAEMON inherited or a login profile exported no longer reaches the CLI.

**Contents:** [🐛 Symptom](#user-content-symptom) · [🔍 Cause](#user-content-cause) · [✅ Fix](#user-content-fix) · [📸 Before / After](#user-content-before-after) · [🔁 Where the variable came from](#user-content-where-the-variable-came-from) · [⚠️ Risk](#user-content-risk) · [🔧 Technical overview](#user-content-technical-overview) · [🧪 Proof](#user-content-proof) · [📝 Notes](#user-content-notes)

## 🐛 Symptom <a id="symptom"></a>

"Claude Code CLI loses its TUI colors on Linux" (#37, Omarchy, a `main` checkout, foot and Ghostty alike): open a Claude session and the pane paints all white — no orange logo, no grey hints, no cyan prompt border — while nebula's own sidebar keeps its colours. Thanks @asafmor (#37).

## 🔍 Cause <a id="cause"></a>

Claude Code picks its colour level with chalk's detection, and one variable drops that level to zero outright: `NO_COLOR` (or `FORCE_COLOR=0`). Two things only nebula's launch path can carry deliver it to the CLI. The DAEMON keeps the environment of whichever shell first started it — an agent's tool shell or a CI job, both of which routinely export `NO_COLOR` — and every session inherits that. And an agent launch runs through the user's login shell (`$SHELL -l -i -c 'exec claude …'`) so it sees the real PATH, which sources login-only profiles that a foot or Ghostty window on Linux never does. Either way Claude is told "no colour at all"; the TUI reads only its own environment and keeps painting, so nothing around the pane looked wrong. A clean Linux container rendered Claude in full truecolour inside nebula; a `.bash_profile` exporting `NO_COLOR=1` reproduced the issue exactly.

## ✅ Fix <a id="fix"></a>

- **The pane is one terminal, and the child is told so.** Every PTY child — agent or plain terminal — now gets `TERM=xterm-256color` (as before) and `COLORTERM=truecolor`, and the DAEMON's inherited `NO_COLOR` / `FORCE_COLOR` are dropped before the spawn.
  - the pane is nebula's grid, repainted through ratatui, and that grid keeps 24-bit colour whatever terminal nebula itself runs in
  - the host terminal's `TERM` (`foot`, `xterm-ghostty`, `tmux-256color`) never reaches the child, as before
- **Restated after your profile.** An agent launch now execs `env -u NO_COLOR -u FORCE_COLOR TERM=xterm-256color COLORTERM=truecolor claude …` once the login shell's files have run.
  - `env` execs straight into the CLI, so the agent stays the PTY's direct process — exit codes and signals pass through as before
  - a profile that exports `NO_COLOR` for its scripts keeps doing so for them; only the session's own CLI is exempt
- **The vim modal too.** The editor modal is drawn on the same grid and now hears `COLORTERM=truecolor` as well.
- **Unchanged.** The TUI still honours its own `NO_COLOR` on the way out, so a user who wants no colour anywhere keeps none; the login-shell launch, the CLI probe and the `NEBULA_*` session variables are as they were.

## 📸 Before / After <a id="before-after"></a>

Both frames are the real Linux TUI (a Debian container, `TERM=foot`, Claude Code 2.1.267, driven in tmux) with `export NO_COLOR=1` in `~/.bash_profile`, as a login-only profile would leave it. The SCREENSHOT HARNESS stands in `/bin/cat` for the agent, so it cannot show a Claude screen; these were captured with `tmux capture-pane -e` and rendered with the harness's own `render.py`.

| Before (#37) | After |
|---|---|
| ![Claude Code's theme picker inside nebula on Linux with every row in the default foreground while the sidebar keeps its colours](https://raw.githubusercontent.com/AgentSystemLabs/nebula/pr-assets/agent-pane-colors/before.png) | ![The same screen after the fix: the theme picker's rows, the selected row and the prompt hints in Claude's own colours](https://raw.githubusercontent.com/AgentSystemLabs/nebula/pr-assets/agent-pane-colors/after.png) |

## 🔁 Where the variable came from <a id="where-the-variable-came-from"></a>

```mermaid
flowchart LR
  shell["shell that first ran nebula<br/>(an agent's tool shell, a CI job)<br/>NO_COLOR=1"] -->|inherited| daemon[DAEMON]
  daemon -->|"spawn: TERM, COLORTERM,<br/>drop NO_COLOR / FORCE_COLOR"| login["$SHELL -l -i -c"]
  profile["~/.bash_profile<br/>export NO_COLOR=1"] -->|sourced| login
  login -->|"exec env -u NO_COLOR -u FORCE_COLOR<br/>TERM=xterm-256color COLORTERM=truecolor"| claude["claude<br/>chalk level 3: truecolor"]
  claude -->|"38;2;r;g;b"| grid["nebula's grid (vt100 → ratatui)"]
  grid -->|"TUI's own NO_COLOR still applies"| term[host terminal]
  classDef changed fill:#1f6f4a,color:#fff,stroke:#0b3
  class daemon,login changed
```

Before this PR only the two red-free edges into `login` existed unchanged: the DAEMON passed its `NO_COLOR` straight through, and nothing stood between the profile and the CLI.

## ⚠️ Risk <a id="risk"></a>

**Verdict:** 🟢 Low risk — three environment variables on a path that already set one, verified on Linux and macOS, with the wrapper's command line covered by tests.

| | Level | Why |
|---|---|---|
| 🔒 **Security & production** | Low | No new surface: the same `$SHELL -l -i -c` launch, with `env` (a coreutils binary on every supported system) added to a command line nebula already composes and quotes; nothing user-supplied enters the new prefix. |
| ⚡ **Performance** | Low | Off every hot path: two `env` calls and two unsets at spawn time, and one extra `exec` (env into the CLI) per agent launch. |
| 🧩 **Fit with the codebase** | Low | Follows the existing pattern — `TERM` was already set there and `AGENT_SESSION_VARS` already scrubbed there; the constants join `nebula_core::env` beside every other variable nebula sets. The one departure is `env -u` in the wrapper, which a shell of any flavour (`bash`, `zsh`, `fish`) accepts unchanged. |

**Rollback:** `git revert` of the merge restores the old spawn and wrapper entirely; no PROTOCOL VERSION bump, no store change, no pushed branch beyond this one.

## 🔧 Technical overview <a id="technical-overview"></a>

- **The spawn.** `crates/nebula-daemon/src/pty/mod.rs` — `PtySession::spawn` set `TERM=xterm-256color` and scrubbed the `NEBULA_*` session vars; it now also sets `COLORTERM=truecolor` and removes `NO_COLOR` / `FORCE_COLOR` from the inherited environment, for every child.
- **The wrapper.** `crates/nebula-daemon/src/registry.rs` — `login_shell_wrap` builds `exec env -u NO_COLOR -u FORCE_COLOR TERM=… COLORTERM=… 'prog' 'args'…` from the same constants, so the profile's exports are undone after they run.
- **The constants.** `crates/nebula-core/src/env.rs` — `PANE_TERM`, `PANE_COLORTERM`, `PANE_COLOR_OVERRIDES`, documented with the why; `crates/nebula-tui/src/vim_term.rs` uses the first two for the editor modal.
- **Why it was missed.** Every developer machine here starts the DAEMON from an ordinary terminal and has no login-only colour exports; a clean Linux container showed no bug either. The reproduction needed a `NO_COLOR` on exactly the path nebula adds.
- **Why not `FORCE_COLOR=3`.** Claude Code's own session daemon sets `FORCE_COLOR=3 COLORTERM=truecolor` for the sessions it hosts, and that would also survive a profile's `NO_COLOR`; but `FORCE_COLOR` is inherited by every tool the agent runs and makes chalk-based tools colour piped output, so unsetting the overrides and letting `COLORTERM` carry the level was chosen instead. A profile that exports `FORCE_COLOR=0` is undone the same way.
- **Docs.** `docs/how-it-works.md` gains "Every pane is the same truecolor terminal".

## 🧪 Proof <a id="proof"></a>

- **Regression tests.** `pty::tests::child_is_told_the_pane_is_a_truecolor_terminal` spawns `/bin/sh` under `NO_COLOR=1 FORCE_COLOR=0 TERM=foot` and reads back `xterm-256color|truecolor|unset|unset`; `registry::tests::login_shell_wrap_restates_the_pane_after_the_profile` runs the wrapper's command line through `sh -c` with the overrides exported and reads back the same. Both fail on `origin/main`.
- **Linux.** The fixed binary, built in a `rust:1-bookworm` container, renders Claude's theme picker in truecolour with `NO_COLOR=1` in `~/.bash_profile` and, separately, with `NO_COLOR=1` in the DAEMON's environment; the child's environment shows only `TERM` and `COLORTERM`.
- **Gate.** `cargo fmt --check`, `cargo clippy --workspace --all-targets` clean; `cargo test --workspace --lib` (839 tests) and the `e2e_pty` / `e2e_tui` suites (37 tests) green on macOS.

## 📝 Notes <a id="notes"></a>

- Branches from `origin/main` after #41; no conflicts. No upgrade step — the next DAEMON start picks it up.
- A reporter who still sees white after upgrading can check the shell that started the DAEMON (`nebula kill`, then relaunch from a plain terminal) and grep `~/.bash_profile` / `~/.profile` for `FORCE_COLOR=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjBECQHCZxZ79Ty25puFzF
